### PR TITLE
feat(ghl): tag "Demande 3 soumissions" hot lead CTA

### DIFF
--- a/app/api/leads/update/route.ts
+++ b/app/api/leads/update/route.ts
@@ -1,5 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { isGHLEnabled, findGHLContactByEmail, appendGHLNote } from "@/lib/ghl-client"
+import { isGHLEnabled, findGHLContactByEmail, appendGHLNote, addGHLContactTag } from "@/lib/ghl-client"
+
+const PRECISE_QUOTE_ACTION = 'clicked_precise_quote_button'
+const DEMANDE_3_SOUMISSIONS_TAG = 'Demande 3 soumissions'
 
 export async function POST(request: NextRequest) {
   try {
@@ -40,11 +43,21 @@ export async function POST(request: NextRequest) {
       }
       const noteBody = `[${new Date().toISOString()}] Action: ${action} (leadId=${leadId})`
       const ok = await appendGHLNote(contact.id, noteBody)
+
+      // For "demande 3 soumissions" CTA: also tag the contact so a downstream
+      // GHL workflow can move the opportunity to the "ask for 3 soumissions"
+      // stage and notify the setter that this is a hot lead.
+      let tagAdded = false
+      if (action === PRECISE_QUOTE_ACTION) {
+        tagAdded = await addGHLContactTag(contact.id, DEMANDE_3_SOUMISSIONS_TAG)
+        console.log(`🔥 LEAD UPDATE: hot lead — tag '${DEMANDE_3_SOUMISSIONS_TAG}' added=${tagAdded}`)
+      }
+
       return NextResponse.json({
         success: ok,
         leadId,
         action,
-        ghl: { contactId: contact.id, noteAppended: ok },
+        ghl: { contactId: contact.id, noteAppended: ok, hotLeadTagAdded: tagAdded },
       })
     }
 

--- a/lib/ghl-client.ts
+++ b/lib/ghl-client.ts
@@ -255,3 +255,23 @@ export async function appendGHLNote(contactId: string, body: string): Promise<bo
   })
   return res.ok
 }
+
+/**
+ * Add a tag to a GHL contact. Used to flag a lead as "Demande 3 soumissions"
+ * when the client clicks the precise-quote CTA on the pricing calculator —
+ * this triggers a downstream GHL workflow that moves the opportunity to the
+ * "ask for 3 soumissions" stage.
+ *
+ * Endpoint: POST /contacts/{contactId}/tags
+ * Body: { tags: [string, ...] }
+ * Idempotent: GHL silently ignores duplicates if the tag is already present.
+ */
+export async function addGHLContactTag(contactId: string, tag: string): Promise<boolean> {
+  const apiKey = process.env.GHL_API_KEY
+  if (!apiKey || !contactId || !tag) return false
+  const res = await ghlRequest(apiKey, `/contacts/${contactId}/tags`, {
+    method: 'POST',
+    body: JSON.stringify({ tags: [tag] }),
+  })
+  return res.ok
+}


### PR DESCRIPTION
## Summary

Adds an automatic GHL tag when a client clicks "Obtenir mes 3 soumissions" on the pricing calculator. Downstream GHL workflow (configured in UI) will trigger off this tag to move the opportunity to the "ask for 3 soumissions" stage and notify setters that this is a hot lead.

## Why

Requested by Zack — clients who explicitly click the precise-quote CTA are higher-intent than passive form submitters. Currently the GHL branch of `/api/leads/update` only appends a note, which is invisible to workflow triggers. Adding a tag makes the signal actionable.

## What changed

- **`lib/ghl-client.ts`**: new helper `addGHLContactTag(contactId, tag)` → `POST /contacts/{id}/tags`. Idempotent (GHL silently ignores duplicate tags).
- **`app/api/leads/update/route.ts`**: when `action === 'clicked_precise_quote_button'` AND `GHL_ENABLED=true`, the branch now also tags the contact with `"Demande 3 soumissions"` after appending the existing note. The tag is gated on the action value so other update calls don't trip the workflow.

## Behavior matrix

| `GHL_ENABLED` | `action` | Behavior |
|---|---|---|
| `false` (current prod) | any | Legacy Make path unchanged — no tag |
| `true` (post-cutover) | `clicked_precise_quote_button` | Note + Tag added |
| `true` | other | Note only (existing behavior) |

## Test plan

- [ ] Vercel preview deploy with `GHL_ENABLED=true`
- [ ] `curl POST /api/leads/update` with `action=clicked_precise_quote_button` + email of an existing GHL contact → verify tag `Demande 3 soumissions` appears in GHL UI
- [ ] `curl POST /api/leads/update` with a different action → verify tag NOT added
- [ ] Confirm `GHL_ENABLED=false` keeps the Make legacy path intact (no tag)

## Companion

PR exists in Powerflow-Dev/Soumission-toiture.ai with identical changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)