### PR TITLE
fix: preserve fbclid during internal navigation

### DIFF
--- a/app/couvreur-shawinigan/page.tsx
+++ b/app/couvreur-shawinigan/page.tsx
@@ -4,13 +4,33 @@ import { AddressInput } from "@/components/address-input"
 import { useLanguage } from "@/lib/language-context"
 import { Badge } from "@/components/ui/badge"
 import { Calculator, TrendingDown, Shield, Clock, Users, MapPin, CheckCircle, Award } from 'lucide-react'
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
+import { getCurrentUTMParameters } from "@/lib/utm-utils"
 
 function ToitureShawiniganPage() {
   const { t } = useLanguage()
   const router = useRouter()
   const [address, setAddress] = useState("")
+
+  useEffect(() => {
+    getCurrentUTMParameters()
+  }, [])
+
+  const navigateToAnalysis = () => {
+    if (!address.trim()) return
+    const utm = getCurrentUTMParameters()
+    const origin = typeof window !== 'undefined' ? window.location.origin : ''
+    const url = new URL('/analysis', origin || 'http://localhost')
+    url.searchParams.set('address', address.trim())
+    url.searchParams.set('region', 'shawinigan')
+    ;(['utm_source','utm_campaign','utm_content','utm_medium','utm_term','fbclid'] as const).forEach((k) => {
+      const v = (utm as any)[k]
+      if (v) url.searchParams.set(k, v)
+    })
+    const href = origin ? url.toString().replace(origin, '') : url.toString()
+    router.push(href)
+  }
 
   return (
     <div className="min-h-screen bg-[#fffff6]">
@@ -115,11 +135,7 @@ function ToitureShawiniganPage() {
                   </label>
                   <AddressInput
                     onAddressSelect={setAddress}
-                    onAnalyze={() => {
-                      if (address.trim()) {
-                        router.push(`/analysis?address=${encodeURIComponent(address)}&region=shawinigan`)
-                      }
-                    }}
+                    onAnalyze={navigateToAnalysis}
                   />
                 </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -85,7 +85,7 @@ export default function HomePage() {
     const origin = typeof window !== 'undefined' ? window.location.origin : ''
     const url = new URL('/analysis', origin || 'http://localhost')
     url.searchParams.set('address', address.trim())
-    ;(['utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term'] as const).forEach((k) => {
+    ;(['utm_source', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_term', 'fbclid'] as const).forEach((k) => {
       const v = (utm as any)[k]
       if (v) url.searchParams.set(k, v)
     })

--- a/app/thermopompes/page.tsx
+++ b/app/thermopompes/page.tsx
@@ -293,11 +293,7 @@ export default function ThermopompesPage() {
           estimatedPriceMin: priceRange?.min,
           estimatedPriceMax: priceRange?.max,
           eventId,
-          utmParams: {
-            utm_source: utmParams.utm_source,
-            utm_campaign: utmParams.utm_campaign,
-            utm_content: utmParams.utm_content
-          }
+          utmParams,
         })
       })
     } catch (error) {

--- a/app/urgence-toiture/page.tsx
+++ b/app/urgence-toiture/page.tsx
@@ -28,7 +28,7 @@ export default function UrgenceToiturePage() {
     const origin = typeof window !== 'undefined' ? window.location.origin : ''
     const url = new URL('/analysis', origin || 'http://localhost')
     url.searchParams.set('address', address.trim())
-    ;(['utm_source','utm_campaign','utm_content','utm_medium','utm_term'] as const).forEach((k) => {
+    ;(['utm_source','utm_campaign','utm_content','utm_medium','utm_term','fbclid'] as const).forEach((k) => {
       const v = (utm as any)[k]
       if (v) url.searchParams.set(k, v)
     })

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -26,7 +26,7 @@ export function HeroSection() {
     const origin = typeof window !== 'undefined' ? window.location.origin : ''
     const url = new URL('/analysis', origin || 'http://localhost')
     url.searchParams.set('address', address.trim())
-    ;(['utm_source','utm_campaign','utm_content','utm_medium','utm_term'] as const).forEach((k) => {
+    ;(['utm_source','utm_campaign','utm_content','utm_medium','utm_term','fbclid'] as const).forEach((k) => {
       const v = (utm as any)[k]
       if (v) url.searchParams.set(k, v)
     })

--- a/lib/utm-utils.ts
+++ b/lib/utm-utils.ts
@@ -76,10 +76,12 @@ export function getCurrentUTMParameters(): UTMParameters {
   // First try to get from current URL
   const currentParams = extractUTMParameters()
   
-  // If we found UTM params in URL, store them and return
+  // If we found UTM params in URL, merge with stored and return
   if (Object.keys(currentParams).length > 0) {
-    storeUTMParameters(currentParams)
-    return currentParams
+    const stored = getStoredUTMParameters()
+    const merged = { ...stored, ...currentParams }
+    storeUTMParameters(merged)
+    return merged
   }
   
   // Otherwise, try to get from stored parameters


### PR DESCRIPTION
## Summary
- **Root cause**: `hero-section.tsx`, `page.tsx` and `urgence-toiture/page.tsx` forwarded `utm_*` params in the navigation URL to `/analysis` but NOT `fbclid`. On `/analysis`, `getCurrentUTMParameters()` detected UTMs in the URL → overwrote sessionStorage → erased the previously stored fbclid.
- **Additional bug**: `thermopompes/page.tsx` explicitly constructed a partial `utmParams` object with only 3 fields, dropping `fbclid` for all HVAC leads.

## Changes
- Forward `fbclid` alongside `utm_*` params in internal navigation URLs
- Merge URL params with stored sessionStorage params (instead of overwriting) so fbclid persists even when absent from current URL
- Pass full `utmParams` object in thermopompes instead of partial rebuild

## Test plan
- [ ] Visit `soumissionconfort.com/?utm_source=test&fbclid=TESTFBCLID123`
- [ ] Enter address → click "Analyser" → verify URL has `fbclid=TESTFBCLID123`
- [ ] Complete questionnaire → submit test lead
- [ ] Verify in GHL that contact has `fbclid = TESTFBCLID123`
- [ ] Test thermopompes flow with same params
- [ ] Test urgence-toiture flow with same params

🤖 Generated with [Claude Code](https://claude.com/claude-code)