### PR TITLE
fix: allow soumissionconfort.com origin in places API routes

### DIFF
--- a/app/api/places/autocomplete/route.ts
+++ b/app/api/places/autocomplete/route.ts
@@ -4,7 +4,7 @@ export async function GET(request: NextRequest) {
   try {
     // Block external callers to protect Google Places quota
     const origin = request.headers.get('origin') || request.headers.get('referer') || ''
-    const allowedHosts = ['localhost', '127.0.0.1', 'soumissionconfort.ai', 'soumission-confort-ai.vercel.app']
+    const allowedHosts = ['localhost', '127.0.0.1', 'soumissionconfort.com', 'soumissionconfort.ai', 'soumission-confort-ai.vercel.app']
     const isAllowed = allowedHosts.some(h => origin.includes(h)) || !origin
     if (!isAllowed) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })

--- a/app/api/places/details/route.ts
+++ b/app/api/places/details/route.ts
@@ -6,7 +6,7 @@ export async function GET(request: NextRequest) {
   try {
     // Block external callers to protect Google Places quota
     const origin = request.headers.get('origin') || request.headers.get('referer') || ''
-    const allowedHosts = ['localhost', '127.0.0.1', 'soumissionconfort.ai', 'soumission-confort-ai.vercel.app']
+    const allowedHosts = ['localhost', '127.0.0.1', 'soumissionconfort.com', 'soumissionconfort.ai', 'soumission-confort-ai.vercel.app']
     const isAllowed = allowedHosts.some(h => origin.includes(h)) || !origin
     if (!isAllowed) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })


### PR DESCRIPTION
## Summary
- Origin check added in a9591d3 only whitelisted `soumissionconfort.ai`, so every user on the production domain `soumissionconfort.com` got **403 Forbidden** from `/api/places/autocomplete` and `/api/places/details`.
- UI effect: the address field on the homepage showed "Failed to fetch predictions" as soon as the user typed anything — form was unusable for 100% of `.com` visitors.
- Fix: add `soumissionconfort.com` to the `allowedHosts` list in both routes (keeps `.ai`, `vercel.app`, and localhost working).

## Test plan
- [x] `curl -H "Origin: https://soumissionconfort.com" .../api/places/autocomplete` → **200** (was 403)
- [x] `curl -H "Origin: https://soumissionconfort.ai" .../api/places/autocomplete` → **200** (non-regression)
- [x] `curl -H "Origin: https://evil.example.com" .../api/places/autocomplete` → **403** (still blocked)
- [x] Same 3 checks on `/api/places/details`
- [ ] After merge + deploy: type an address on https://soumissionconfort.com and confirm Google Places suggestions render

🤖 Generated with [Claude Code](https://claude.com/claude-code)