### PR TITLE
fix: allow www subdomain origins in Places API

### DIFF
--- a/lib/allowed-origins.ts
+++ b/lib/allowed-origins.ts
@@ -2,7 +2,9 @@ import type { NextRequest } from "next/server"
 
 const ALLOWED_HOSTNAMES_PROD = new Set([
   "soumissionconfort.com",
+  "www.soumissionconfort.com",
   "soumissionconfort.ai",
+  "www.soumissionconfort.ai",
   "soumission-confort-ai.vercel.app",
 ])
 

--- a/lib/allowed-origins.ts
+++ b/lib/allowed-origins.ts
@@ -1,17 +1,26 @@
 import type { NextRequest } from "next/server"
 
-const ALLOWED_HOSTNAMES_PROD = new Set([
+const APEX_DOMAINS = [
   "soumissionconfort.com",
-  "www.soumissionconfort.com",
   "soumissionconfort.ai",
-  "www.soumissionconfort.ai",
-  "soumission-confort-ai.vercel.app",
-])
+] as const
 
-const ALLOWED_HOSTNAMES_DEV = new Set([
+const PREVIEW_HOSTS = [
+  "soumission-confort-ai.vercel.app",
+] as const
+
+const DEV_HOSTS = [
   "localhost",
   "127.0.0.1",
+] as const
+
+export const ALLOWED_HOSTNAMES_PROD = new Set<string>([
+  ...APEX_DOMAINS,
+  ...APEX_DOMAINS.map((d) => `www.${d}`),
+  ...PREVIEW_HOSTS,
 ])
+
+export const ALLOWED_HOSTNAMES_DEV = new Set<string>(DEV_HOSTS)
 
 function normalizeHostname(raw: string): string {
   return raw.toLowerCase().replace(/\.$/, "")

--- a/tests/lib/allowed-origins.test.ts
+++ b/tests/lib/allowed-origins.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { NextRequest } from "next/server"
+import { isAllowedOrigin } from "../../lib/allowed-origins"
+
+function makeRequest(headers: Partial<Record<"origin" | "referer", string>>): NextRequest {
+  return {
+    headers: {
+      get(name: string) {
+        const key = name.toLowerCase() as "origin" | "referer"
+        return headers[key] ?? null
+      },
+    },
+  } as unknown as NextRequest
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe("isAllowedOrigin — production hostnames", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "production")
+  })
+
+  it.each([
+    "https://soumissionconfort.com",
+    "https://www.soumissionconfort.com",
+    "https://soumissionconfort.ai",
+    "https://www.soumissionconfort.ai",
+    "https://soumission-confort-ai.vercel.app",
+  ])("allows %s", (origin) => {
+    expect(isAllowedOrigin(makeRequest({ origin }))).toBe(true)
+  })
+
+  it("allows uppercase + trailing-dot hostnames", () => {
+    const req = makeRequest({ origin: "https://WWW.SOUMISSIONCONFORT.COM./path" })
+    expect(isAllowedOrigin(req)).toBe(true)
+  })
+
+  it("falls back to Referer when Origin is absent", () => {
+    const req = makeRequest({ referer: "https://www.soumissionconfort.com/merci" })
+    expect(isAllowedOrigin(req)).toBe(true)
+  })
+})
+
+describe("isAllowedOrigin — denied origins", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "production")
+  })
+
+  it.each([
+    "https://soumissionconfort.com.evil.io",
+    "https://www.soumissionconfort.com.evil.io",
+    "https://evil.vercel.app",
+    "https://soumissionconfort-evil.com",
+  ])("denies %s", (origin) => {
+    expect(isAllowedOrigin(makeRequest({ origin }))).toBe(false)
+  })
+
+  it("denies when both Origin and Referer are missing", () => {
+    expect(isAllowedOrigin(makeRequest({}))).toBe(false)
+  })
+
+  it("denies when header is not a valid URL", () => {
+    expect(isAllowedOrigin(makeRequest({ origin: "not-a-url" }))).toBe(false)
+  })
+
+  it("denies localhost in production", () => {
+    expect(isAllowedOrigin(makeRequest({ origin: "http://localhost:3000" }))).toBe(false)
+    expect(isAllowedOrigin(makeRequest({ origin: "http://127.0.0.1:3000" }))).toBe(false)
+  })
+
+  it("denies spoofed localhost via Referer in production", () => {
+    const req = makeRequest({ referer: "http://localhost/attack" })
+    expect(isAllowedOrigin(req)).toBe(false)
+  })
+})
+
+describe("isAllowedOrigin — development mode", () => {
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "development")
+  })
+
+  it("allows localhost in dev", () => {
+    expect(isAllowedOrigin(makeRequest({ origin: "http://localhost:3000" }))).toBe(true)
+    expect(isAllowedOrigin(makeRequest({ origin: "http://127.0.0.1:3000" }))).toBe(true)
+  })
+
+  it("still denies superstring attacks in dev", () => {
+    const req = makeRequest({ origin: "https://soumissionconfort.com.evil.io" })
+    expect(isAllowedOrigin(req)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- PR #12/#13 hardened the Places API origin check but only added the bare `soumissionconfort.com` / `soumissionconfort.ai` hostnames to the allowlist.
- Production redirects `soumissionconfort.com → www.soumissionconfort.com` (308), so every real user hits the `www` subdomain and gets a **403 Forbidden** on `/api/places/autocomplete` + `/api/places/details`.
- Adding `www.soumissionconfort.com` and `www.soumissionconfort.ai` to `ALLOWED_HOSTNAMES_PROD` in [lib/allowed-origins.ts](lib/allowed-origins.ts).

## Live verification (before)
```
Origin: https://soumissionconfort.com         → 200 ✅
Origin: https://soumissionconfort.ai          → 200 ✅
Origin: https://www.soumissionconfort.com     → 403 ❌  ← real users
```

## Test plan
- [ ] After merge + Vercel deploy, curl `/api/places/autocomplete?input=montreal` with `Origin: https://www.soumissionconfort.com` → expect 200
- [ ] Smoke-test address autocomplete on https://www.soumissionconfort.com (hero form)
- [ ] Superstring attack (`www.soumissionconfort.com.evil.io`) still → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)