### PR TITLE
feat: Phase 1 funnel V2 /analysis — 3-question wizard + lead form

### DIFF
--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -29,6 +29,19 @@ NEXT_PUBLIC_META_PIXEL_ID=votre_pixel_id
 META_CONVERSION_API_TOKEN=votre_token_conversion_api
 META_PIXEL_ID=votre_pixel_id
 
+# ----------------------------------------------------------------------------
+# Pixel dédié soumissionconfort — funnel /analysis V2 (Phase 2)
+# ----------------------------------------------------------------------------
+# Utilisé UNIQUEMENT par le funnel /analysis (+ /verifier-telephone). Les autres
+# funnels (/thermopompes, /subventions, /soumission-rapide) restent sur
+# NEXT_PUBLIC_META_PIXEL_ID. Pixel créé dans le Business Manager soumissionconfort,
+# séparé du pixel Niku → audience isolation 100% clean.
+# Placeholder XXXXXX = skip strict (aucun pixel browser, aucun CAPI) tant que le
+# pixel n'existe pas, sans polluer le pixel actuel.
+NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT=votre_pixel_id_soumissionconfort
+META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT=votre_token_capi_soumissionconfort
+META_TEST_EVENT_CODE_SOUMISSIONCONFORT=  # optionnel — Events Manager → Test Events
+
 
 # ============================================================================
 # CRM / WEBHOOKS

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -38,8 +38,11 @@ META_PIXEL_ID=votre_pixel_id
 # séparé du pixel Niku → audience isolation 100% clean.
 # Placeholder XXXXXX = skip strict (aucun pixel browser, aucun CAPI) tant que le
 # pixel n'existe pas, sans polluer le pixel actuel.
-NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT=votre_pixel_id_soumissionconfort
-META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT=votre_token_capi_soumissionconfort
+# XXXXXX = placeholder reconnu par le garde-fou (skip strict). Remplacer par les
+# vraies valeurs en prod/preview. NE PAS mettre un texte libre type "votre_..."
+# ici : il ne matche pas /^X+$/ et le code tenterait de l'utiliser comme pixel.
+NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT=XXXXXX
+META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT=XXXXXX
 META_TEST_EVENT_CODE_SOUMISSIONCONFORT=  # optionnel — Events Manager → Test Events
 
 

--- a/PLAN_FUNNEL_V2_ANALYSIS.md
+++ b/PLAN_FUNNEL_V2_ANALYSIS.md
@@ -1,0 +1,451 @@
+# Funnel V2 — `/analysis` (Soumission Confort)
+
+> **Status** : reviewé par Codex (P0 blockers adressés). En attente d'approbation Zack avant code.
+
+## Context
+
+Le funnel **`/soumission-rapide`** (3 soumissions direct) n'est pas actif — aucun lead n'y rentre. Le funnel actif est **`/analysis`** (estimation gratuite, lancé depuis le CTA du homepage "Obtenir mon estimation gratuite").
+
+Un premier essai de refonte V2 a été fait sur la mauvaise branche (`feat/soumissionconfort-funnel-v2-visual`) ciblant `/soumission-rapide`. Le code livré était "gang de la marde" selon Zack. On refait propre, sur `/analysis`, en repartant de `main`.
+
+L'objectif (identique au plan V2 original) :
+1. **Capturer du signal réel** (symptômes vécus + facture Hydro = proxy isolation).
+2. **Différencier qualifié vs curieux** → routing pixel Meta + tag GHL différencié.
+3. **Donner une estimation de coût** à la fin (pricing 3-tier existant conservé visuellement).
+4. **Tracking Meta complet** : PageView → ViewContent → Lead (qualifié only), browser + CAPI dedupé.
+
+Référence : `PLAN_FUNNEL_V2.md` (701 lignes, sur la branche v2-visual) reste valide sur la philosophie produit. On l'adapte à l'architecture de `/analysis` (state machine single-page) au lieu de `/soumission-rapide` (pages séparées).
+
+## Décisions verrouillées (issues du brief Zack)
+
+| Sujet | Décision |
+|---|---|
+| Funnel cible | `/analysis` (estimation gratuite, funnel actif) |
+| `/soumission-rapide` | Pas touché. La branche `feat/soumissionconfort-funnel-v2-visual` reste sur le remote, non mergée, ignorée. |
+| Branche neuve | `feat/analysis-funnel-v2` from `main` |
+| Adresse | Collectée sur le homepage, passée en URL param, déclenche `/api/roof-analysis`. **Pas re-demandée dans le wizard.** |
+| Questionnaire | **3 questions visibles** : Q1 symptômes / Q2 hydro / Q3 intent. Numérotation "Question 1/3", "2/3", "3/3". |
+| Lead form | **Full-page** sur `/analysis` (state `lead-capture`). Remplace le popup `LeadCapturePopup` actuel **uniquement sur `/analysis`** — le popup reste utilisé par `/thermopompes` (cf P1-3 Codex). |
+| Estimation finale | **Pricing 3-tier visuel inchangé** (`InsulationResults` + sa route `/pricing?leadId=…&d=…`). Calcul reste piloté par `calculateInsulationPricing`. Voir P0-3 pour la dégradation acceptée Phase 1. |
+| Phases | **2 phases séparées** mergées ensemble à la fin. Phase 1 = visuel. Phase 2 = backend (Meta pixel + GHL tags). |
+| Meta Pixel ID + Token | Placeholders `XXXXXX` jusqu'à création par Zack. |
+
+## P0 blockers adressés (review Codex)
+
+### P0-1 — Lead capture state machine cassé aujourd'hui
+
+**Findings Codex** : `app/analysis/page.tsx:317-318` ne render `LeadCaptureForm` que si `leadData` existe déjà ; le `LeadCaptureForm` actuel ne calcule pas `pricingData` et redirige vers `/success` au lieu d'appeler `onComplete` ; `/api/leads:89-95` exige `pricingData` pour les isolation leads.
+
+**Conséquence** : `lead-capture` est aujourd'hui un dead path. Le wizard popup actuel gère tout (calcule pricing + POST + route vers `/pricing`). Si on bascule à un full-page lead form sans toucher le reste, on casse le funnel.
+
+**Fix Phase 1** :
+1. Le wizard V2 (3 Qs) appelle `onComplete(answers)` avec **seulement les answers** — pas de pricing, pas de lead data.
+2. Le state machine `/analysis` :
+   - state `questionnaire` → render wizard V2
+   - state `lead-capture` → render **nouveau** `LeadCaptureForm` full-page (refonte complète) qui :
+     - Affiche le form contact (prénom/nom/email/tél)
+     - Sur submit : calcule `pricingData` via `calculateInsulationPricing` (avec mapping V2 → V1 inputs, cf P0-3) + POST `/api/leads` (payload complet incluant `pricingData`) + handle OTP path
+   - state `pricing` → `InsulationResults` inchangé
+3. Render condition de `lead-capture` change : `roofData && userAnswers` (pas `leadData`).
+4. Le nouveau `LeadCaptureForm` retourne via `onComplete(pricingData, leadData, leadId)` pour avancer le state machine vers `pricing` (chemin non-OTP).
+
+### P0-2 — OTP return path doit utiliser le pattern existant `/pricing?leadId=…&d=…`
+
+**Findings Codex** : Mon plan disait "OTP → retour `/analysis` step pricing". Mais `/verifier-telephone:17-32, :183-184` redirige vers `otp-verify.redirectTo` (par défaut `/success`). Le flow actuel marche parce que [`/analysis/page.tsx:182-187`](soumissionconfort/app/analysis/page.tsx#L182-L187) override `redirectTo` à `/pricing?leadId=…&d=…` avec les données encodées en base64.
+
+**Fix Phase 1** : Réutiliser EXACTEMENT le pattern existant `/pricing?leadId=${leadId}&d=${urlData}`. Le nouveau `LeadCaptureForm` :
+- En path OTP : stash `pending-lead` + override `otp-verify.redirectTo` vers `/pricing?leadId=…&d=…` + `router.push('/verifier-telephone')`.
+- En path non-OTP : `setCurrentStep('pricing')` avec `pricingData` via `onComplete`.
+
+**Note** : `urlData` actuel encode `roofArea`, `pitch`, `heatingSystem`, `currentInsulation`, `atticAccess`, `identifiedProblems`. On garde ces clés en V1 → V2 mapping (cf P0-3) pour que `/pricing` continue de fonctionner sans modification.
+
+### P0-3 — Pricing 3-tier dégrade si on supprime les V1 answers
+
+**Findings Codex** : [`lib/insulation-calculator.ts:75-84, :145-153, :164-177, :231-261`](soumissionconfort/lib/insulation-calculator.ts) utilise `currentInsulation`, `atticAccess`, `heatingSystem`, `identifiedProblems` pour personnaliser cost/savings. Si on les retire, le calcul retombe sur fallback (Math.max + multiplicateurs hardcodés). Le pricing 3-tier devient générique.
+
+**Décision Phase 1 — mapping V2 → V1 avec defaults conservateurs** :
+
+```ts
+// Dans le nouveau LeadCaptureForm, avant calcul pricing :
+const v1AnswersForPricing = {
+  // V1 defaults conservateurs — pas idéal mais marche sans casser
+  heatingSystem: 'electricite',      // majorité Quebec
+  currentInsulation: 'partielle',    // assomption moyenne
+  atticAccess: 'facile',             // assomption moyenne
+  // V2 → V1 partial mapping
+  identifiedProblems: mapV2SymptomsToV1(v2Answers.symptoms),
+}
+
+function mapV2SymptomsToV1(v2Symptoms: string[]) {
+  const map: Record<string, string> = {
+    humidity_mold: 'moisissure',
+    drafts: 'courants-air',
+    hydro_up: 'factures-elevees',
+    uneven_temp: 'temperature-inegale',
+    ice_roof: 'glace',
+    cold_winter: 'temperature-inegale',  // mapping approximatif
+    hot_summer: 'temperature-inegale',   // mapping approximatif
+  }
+  const v1 = v2Symptoms.map(s => map[s]).filter(Boolean)
+  return v1.length ? v1 : ['aucun']
+}
+```
+
+**Limitation acceptée Phase 1** : pricing devient moins précis sur les axes `heatingSystem` / `currentInsulation` / `atticAccess`. Documenter dans le PR description. **Phase 3 (post-merge V2) potentielle** : étendre `calculateInsulationPricing` pour accepter `symptoms` + `hydroBracket` comme inputs réels et raffiner le calcul. Pas dans le scope V2.
+
+### P0-4 — Payload `/api/leads` + GHL custom fields + Make webhook
+
+**Findings Codex** : 
+- [`app/api/leads/route.ts:204-230`](soumissionconfort/app/api/leads/route.ts#L204-L230) GHL custom fields use `currentInsulation`, `atticAccess`, etc.
+- [`:476-492`](soumissionconfort/app/api/leads/route.ts#L476-L492) legacy webhook project details use same keys.
+- [`:650-656`](soumissionconfort/app/api/leads/route.ts#L650-L656) Make columns use old labels.
+- [`WEBHOOK_PAYLOAD_STRUCTURE.md:81-100`](soumissionconfort/WEBHOOK_PAYLOAD_STRUCTURE.md#L81-L100) contract documents old fields.
+
+**Fix Phase 1 — backward-compatible payload** :
+
+Le nouveau `LeadCaptureForm` construit un payload qui inclut **les anciens champs avec defaults conservateurs** ET **les nouveaux champs V2 en passthrough** :
+
+```ts
+const leadPayload = {
+  firstName, lastName, email, phone, leadId,
+  roofData,
+  userAnswers: {
+    // V1 fields (defaults pour ne pas casser GHL/Make)
+    heatingSystem: 'electricite',
+    currentInsulation: 'partielle',
+    atticAccess: 'facile',
+    identifiedProblems: mapV2SymptomsToV1(v2.symptoms),
+    // V2 fields (nouveau, passthrough Phase 1)
+    symptoms: v2.symptoms,           // string[]
+    hydroBracket: v2.hydroBracket,   // 'lt_125' | '125_200' | '200_300' | 'gt_300'
+    intent: v2.intent,               // 'qualified' | 'curious'
+  },
+  pricingData,
+  utmParams,
+  eventId,
+}
+```
+
+**Phase 1 = aucune modif `/api/leads`, `lib/ghl-fields-iso.ts`, `lib/ghl-client.ts`, Make webhook column mapping**. Les nouveaux champs sont dans le payload mais ignorés silencieusement par les consumers existants. Make reçoit les colonnes attendues (les V1 defaults). GHL custom fields V1 sont remplis avec les defaults.
+
+**Phase 2** : on câble explicitement `symptoms`/`hydroBracket`/`intent` dans GHL (nouveaux fields ou reuse `problemes_identifies` TEXT), Make (nouvelles colonnes), webhook contract.
+
+## P1 — Items à fixer dans le plan
+
+### P1-1 — Phase 1 contradiction "aucun backend"
+
+**Fix** : Phase 1 = aucune modif `app/api/leads/route.ts`, `lib/ghl-fields-iso.ts`, `lib/ghl-client.ts`, `lib/meta-config.ts`. Seuls fichiers backend touchés Phase 1 : **aucun**. Les nouveaux champs V2 voyagent dans le payload mais sont passthrough (pas câblés). Le wizard + lead form + state machine `/analysis` = scope Phase 1 only.
+
+### P1-2 — Nouveaux GHL fields n'existent pas
+
+Phase 2 only. Plusieurs options à trancher avec Zack avant Phase 2 :
+- (a) Créer 3 nouveaux fields GHL (`symptoms`, `hydro_bracket`, `intent`) via le script de generation `setup-ghl-iso-custom-fields.ts` si pattern existe.
+- (b) Reuse `problemes_identifies` (TEXT) pour `symptoms` CSV, créer 2 fields pour `hydro_bracket` + `intent`.
+- (c) Créer 1 super-field `funnel_v2_metadata` JSON qui contient tout.
+
+Recommandation Phase 2 : option (a) — fields dédiés = visibilité claire dans GHL UI pour les setters.
+
+### P1-3 — Ne PAS supprimer `LeadCapturePopup` globalement
+
+Utilisé par [`app/thermopompes/page.tsx:12, :1118-1123`](soumissionconfort/app/thermopompes/page.tsx). **On modifie uniquement `app/analysis/page.tsx`** pour ne plus le rendre. Le composant reste dans `components/`.
+
+### P1-4 — Meta Lead pixel fire trop tôt (Phase 2)
+
+**Findings Codex** : Browser Lead fire dans le wizard ([`user-questionnaire-wizard.tsx:199-211`](soumissionconfort/components/user-questionnaire-wizard.tsx#L199-L211)) AVANT l'OTP. Server CAPI fire dans les 2 branches ([`api/leads/route.ts:269-314, :747-819`](soumissionconfort/app/api/leads/route.ts)).
+
+**Fix Phase 2** :
+- Retirer le `window.fbq('track', 'Lead', ...)` du wizard.
+- Browser Lead fire dans `/verifier-telephone` APRÈS retour OK de `/api/verify-otp`, gated par `intent === 'qualified'`.
+- Si OTP off : fire dans le `LeadCaptureForm` APRÈS retour OK de `/api/leads`, gated par `intent === 'qualified'`.
+- Server CAPI : gate les 2 branches `/api/leads` par `intent === 'qualified'`.
+- Retirer le `CompleteRegistration` event (grep le repo, probablement sur `/success` ou similaire).
+
+### P1-5 — Auto-advance race condition
+
+[`user-questionnaire-wizard.tsx:102-109`](soumissionconfort/components/user-questionnaire-wizard.tsx#L102-L109) utilise `setTimeout(setCurrentStep, 250)` sans cleanup. Si le user double-click ou unmount avant 250ms → bug.
+
+**Fix Phase 1** : ajouter click guard (`isAdvancing` state) + `useEffect` cleanup du timeout. Pattern :
+```ts
+const [isAdvancing, setIsAdvancing] = useState(false)
+const advanceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+useEffect(() => () => { if (advanceTimeoutRef.current) clearTimeout(advanceTimeoutRef.current) }, [])
+const selectAndAdvance = (field, value) => {
+  if (isAdvancing) return
+  setIsAdvancing(true)
+  setAnswers(prev => ({ ...prev, [field]: value }))
+  advanceTimeoutRef.current = setTimeout(() => {
+    setCurrentStep(s => s + 1)
+    setIsAdvancing(false)
+  }, 250)
+}
+```
+
+### P1-6 — `/analysis` sans address ne redirige pas aujourd'hui
+
+[`app/analysis/page.tsx:52-55`](soumissionconfort/app/analysis/page.tsx#L52-L55) : si pas d'adresse, le effect return early et `currentStep` reste à `"loading"`. Le spinner tourne indéfiniment.
+
+**Fix Phase 1** : ajouter au début du `useEffect` :
+```ts
+if (typeof window === 'undefined') return
+if (!address) {
+  router.push('/')
+  return
+}
+```
+
+### P1-7 — Analytics events stales
+
+Renommer dans Phase 1 :
+- `'Lead Capture Popup Opened'` → `'Lead Form Shown'` (vu que c'est plus un popup)
+- `'Questionnaire Step Completed'` continue avec les nouvelles step keys (`'symptoms'`, `'hydroBracket'`, `'intent'`)
+- Ajouter `'Lead Form Submitted'` quand le user soumet le full-page form
+
+## P2 — Nice to have
+
+### P2-1 — Bouton "Précédent" Q1
+
+Reste disabled sur Q1 (comportement actuel `user-questionnaire-wizard.tsx:507-510`). Si Zack veut un retour homepage explicite : ajout d'un Link "← Retour à l'accueil" séparé.
+
+### P2-2 — Photo background Q1 — **À CLARIFIER avec Zack**
+
+Codex confirme : le wizard actuel n'a pas de photo background. Les screenshots `q1-reframed.png` et `q1-after-refresh.png` montrent un fond de grenier/isolation. Cet asset n'existe pas dans `public/images/` aujourd'hui.
+
+**Question Zack** : tu as une image en tête à ajouter ? Si oui, source/asset à fournir. Sinon, on garde le fond crème `#fffff6` actuel.
+
+### P2-3 — A11y / focus management lead form
+
+Popup actuel a Dialog focus management automatique ([`lead-capture-popup.tsx:68-69`](soumissionconfort/components/lead-capture-popup.tsx#L68-L69)). Le nouveau full-page form n'en aura pas. Ajout Phase 1 : `useEffect` focus sur premier input au mount du state `lead-capture`.
+
+### P2-4 — sessionStorage keys collision multi-funnels
+
+`/analysis`, `/thermopompes`, `/subventions`, `/soumission-rapide` partagent `pending-lead` / `otp-verify`. Si user navigue entre funnels → état leaked. **Hors scope V2** (existant pre-V2), mais à flagger pour cleanup futur.
+
+### P2-5 — Single PR avec feature flag vs 2 PRs
+
+Codex suggère feature flag. Zack a opté pour 2 PRs mergées ensemble. **Garder 2 PRs** (Phase 1 visuel + Phase 2 backend). Si pendant Phase 1 on découvre que les changements backend Phase 2 sont coupled trop fort, on revisitera.
+
+## Architecture cible — `/analysis` après V2
+
+```
+Homepage
+   ↓ CTA "Obtenir mon estimation gratuite" (URL: /analysis?address=...)
+/analysis state "loading"
+   ↓ /api/roof-analysis (inchangé) → set roofData + redirect missing → /
+/analysis state "questionnaire" — wizard V2 NOUVEAU
+   ├─ Q1/3 Symptômes (multi-select, 7 options emoji) — bouton Suivant
+   ├─ Q2/3 Facture Hydro (4 brackets coloré seuils <125/125-200/200-300/>300) — auto-advance
+   └─ Q3/3 Intent (qualifié / curieux) — auto-advance
+   ↓ onComplete(v2Answers) — answers only, pas de lead/pricing
+/analysis state "lead-capture" — full-page form NOUVEAU
+   ↓ submit prénom/nom/email/tél
+   ↓ calcule pricingData via calculateInsulationPricing(mapV2ToV1Inputs(...))
+   ↓ POST /api/leads (payload backward-compatible : V1 defaults + V2 passthrough)
+   ↓ if OTP_ENABLED:
+        - stash pending-lead + override otp-verify.redirectTo = /pricing?leadId=…&d=…
+        - router.push('/verifier-telephone')
+      else:
+        - setPricingData(pricingData) + setCurrentStep('pricing')
+/analysis state "pricing" — InsulationResults INCHANGÉ
+   └─ Pricing 3-tier (économique/standard/premium)
+```
+
+## Phase 0 — Setup branche + persistance plan
+
+1. Vérifier qu'on est sur `main` et up-to-date : `git fetch && git checkout main && git pull`.
+2. Créer la branche : `git checkout -b feat/analysis-funnel-v2`.
+3. **Copier ce plan dans le repo** :
+   - Source : `/Users/zackdumont/.claude/plans/bon-dans-le-repo-streamed-corbato.md`
+   - Destination : `soumissionconfort/PLAN_FUNNEL_V2_ANALYSIS.md`
+   - Commit dédié : `chore: add V2 funnel /analysis plan as repo reference`
+4. Confirmer `git branch --show-current` = `feat/analysis-funnel-v2`.
+
+Le plan commité sert de référence durable : dans la prochaine session, on peut le relire depuis le repo avec `cat soumissionconfort/PLAN_FUNNEL_V2_ANALYSIS.md` ou via Github.
+
+## Phase 1 — Visuel MVP (branche `feat/analysis-funnel-v2`)
+
+**Scope** : refonte wizard + lead form + state machine `/analysis`. **Zéro modif backend** (`/api/leads`, GHL libs, Meta libs intactes). Payload backward-compatible.
+
+### Fichiers à modifier
+
+| Fichier | Changement |
+|---|---|
+| [components/user-questionnaire-wizard.tsx](soumissionconfort/components/user-questionnaire-wizard.tsx) | Remplacer les 4 étapes actuelles (heating/insulation/attic/problems) par 3 nouvelles (symptoms/hydroBracket/intent). **Retirer entièrement** la logique de lead capture (popup, `handleLeadSubmit`, calcul pricing). Le wizard appelle `onComplete(v2Answers)` avec answers seulement. Ajout click-guard + cleanup timeout (P1-5). Renommer step tracking analytics (P1-7). |
+| [components/lead-capture-form.tsx](soumissionconfort/components/lead-capture-form.tsx) | **Refonte complète**. Nouveau contrat : `props = { roofData, v2Answers, onComplete: (pricingData, leadData, leadId) => void }`. Form full-page (matche `lead-form-qualified.png`). Submit handler : `mapV2ToV1Inputs` → `calculateInsulationPricing` → POST `/api/leads` (payload backward-compatible) → OTP path (pricing URL pattern) OU `onComplete(...)`. Focus management on mount (P2-3). |
+| [app/analysis/page.tsx](soumissionconfort/app/analysis/page.tsx) | State machine update : `questionnaire` → `lead-capture` → `pricing`. Render condition `lead-capture` change : `roofData && userAnswers` (pas `leadData`). `handleQuestionnaireComplete(v2Answers)` set `userAnswers = v2Answers` + advance state. `handleLeadCaptureComplete(pricingData, leadData, leadId)` set state + advance pricing. Redirect `/` si `!address` (P1-6). |
+
+### Fichiers à créer
+
+| Fichier | Rôle |
+|---|---|
+| [lib/funnel-config.ts](soumissionconfort/lib/funnel-config.ts) | Constantes V2 : `SYMPTOMS_OPTIONS`, `HYDRO_BRACKETS`, `INTENT_OPTIONS` + helper `mapV2SymptomsToV1`. |
+
+### Constantes (`lib/funnel-config.ts`)
+
+```ts
+export const SYMPTOMS_OPTIONS = [
+  { code: 'hydro_up',      label: "Ma facture d'Hydro monte chaque année", emoji: '⚡' },
+  { code: 'cold_winter',   label: "Ma maison est froide en hiver",          emoji: '🥶' },
+  { code: 'hot_summer',    label: "C'est étouffant l'été, surtout en haut", emoji: '🥵' },
+  { code: 'ice_roof',      label: "J'ai de la glace ou des glaçons sur le toit", emoji: '🧊' },
+  { code: 'drafts',        label: "Je sens des courants d'air",              emoji: '💨' },
+  { code: 'uneven_temp',   label: "Un étage est chaud, l'autre est froid",   emoji: '🌡️' },
+  { code: 'humidity_mold', label: "J'ai de l'humidité ou de la moisissure",  emoji: '💧' },
+] as const
+
+export const HYDRO_BRACKETS = [
+  { code: 'lt_125',  label: 'Moins de 125 $ / mois',       emoji: '💰',     colorClass: 'border-green-500 bg-green-50' },
+  { code: '125_200', label: 'Entre 125 $ et 200 $ / mois', emoji: '💰💰',   colorClass: 'border-yellow-500 bg-yellow-50' },
+  { code: '200_300', label: 'Entre 200 $ et 300 $ / mois', emoji: '💰💰💰', colorClass: 'border-orange-500 bg-orange-50' },
+  { code: 'gt_300',  label: 'Plus de 300 $ / mois',         emoji: '🔥',     colorClass: 'border-red-500 bg-red-50' },
+] as const
+
+export const INTENT_OPTIONS = [
+  { code: 'qualified', label: 'Je veux faire les travaux',   sub: 'Je suis prêt à recevoir un inspecteur qualifié', emoji: '🔨' },
+  { code: 'curious',   label: 'Je suis juste curieux du coût', sub: 'Juste pour savoir, pas pressé',                emoji: '💭' },
+] as const
+
+export function mapV2SymptomsToV1(v2Symptoms: string[]): string[] {
+  const map: Record<string, string> = {
+    humidity_mold: 'moisissure',
+    drafts: 'courants-air',
+    hydro_up: 'factures-elevees',
+    uneven_temp: 'temperature-inegale',
+    ice_roof: 'glace',
+    cold_winter: 'temperature-inegale',
+    hot_summer: 'temperature-inegale',
+  }
+  const v1 = v2Symptoms.map(s => map[s]).filter(Boolean)
+  return v1.length ? Array.from(new Set(v1)) : ['aucun']
+}
+```
+
+### Visuel de référence (screenshots May 28)
+
+| Question | Screenshot | Détail clé |
+|---|---|---|
+| Q1 (symptômes) | `q2-symptoms.png` | Card blanche, options pleine largeur avec emoji à gauche, sélection = bordure verte + fond vert pâle. CTA "Sélectionne au moins un" disabled tant qu'aucune coche. |
+| Q2 (hydro) | `q3-hydro-4brackets.png` (style) + nouveaux seuils <125/125-200/200-300/>300 | 4 options coloré progressif vert→jaune→orange→rouge. Auto-advance sur sélection. Sub-label "Pas sûr du montant exact? Donne ton meilleur estimé…". |
+| Q3 (intent) | `q4-intent.png` | 2 grosses options avec emoji + label bold + sub-label italic. Auto-advance. |
+| Lead form | `lead-form-qualified.png` | Layout 2 colonnes prénom/nom, courriel pleine largeur, tel pleine largeur. CTA "Obtenir mon estimation" lime. Badges trust + section "Que se passe-t-il ensuite ?" 3 colonnes. |
+
+**Design intégral conservé — ON NE RÉINVENTE RIEN** :
+- Badge "Question X/3 😊" avec smile (cyan #aedee5).
+- Progress bar dégradé : `linear-gradient(7.67deg, #aedee5 0%, #b9e15c 99.27%)`.
+- Fond crème global `#fffff6`.
+- Logo header, navbar, fonts (`font-heading`, `font-serif-body`), `rounded-[20px]`, shadows, borders cyan.
+- Bouton "Précédent" coin gauche bas avec ArrowLeft (disabled sur Q1).
+- États sélectionnés : bordure verte `#86a735` + fond vert pâle `#ecf8cf`.
+- Aucune nouvelle classe Tailwind inventée. Copier les classes du wizard actuel.
+
+**Photo background Q1** : à clarifier (P2-2) — pas implémenté actuellement, asset à fournir par Zack.
+
+### Tests Phase 1 (preview Vercel + manuels)
+
+1. Homepage → CTA → adresse autocomplete → `/analysis?address=...`.
+2. Loading spinner → roof-analysis OK → wizard Q1 symptômes.
+3. Cocher 2-3 symptômes → bouton "Suivant" activé → click → Q2 hydro.
+4. Click sur un bracket hydro → auto-advance vers Q3 intent (vérifier pas de double-click bug).
+5. Click sur intent qualifié → state machine avance vers `lead-capture` (form full-page).
+6. Remplir form → submit → si OTP_ENABLED → redirect `/verifier-telephone` → après OTP OK → arrive sur `/pricing?leadId=…&d=…` qui affiche `InsulationResults`.
+7. Si OTP off → state `pricing` direct dans `/analysis`, affiche `InsulationResults`.
+8. Refaire en sélectionnant intent "curieux" → tout marche pareil (Phase 1, pas de différenciation).
+9. Bouton "Précédent" : Q1 disabled, Q2/Q3 reviennent en arrière sans perdre les réponses précédentes.
+10. Naviguer direct sur `/analysis` sans address → redirect `/`.
+11. `npx tsc --noEmit` clean.
+12. `npm run build` succès.
+13. Grep `LeadCapturePopup` : confirmer que `/thermopompes` continue de l'utiliser (régression check).
+
+### Vérifications avant PR Phase 1
+
+- [ ] Funnel complet du homepage à `InsulationResults` (avec et sans OTP).
+- [ ] Aucune régression sur `/thermopompes` (popup intact).
+- [ ] Aucune régression sur `/subventions`, `/soumission-rapide`.
+- [ ] `/api/leads` reçoit le payload backward-compatible (vérifier via Vercel logs en preview).
+- [ ] GHL reçoit les V1 fields avec defaults (vérifier dans GHL UI pour 1 lead test).
+- [ ] Make scenario reçoit les colonnes attendues.
+- [ ] `npx tsc --noEmit`, `npm run build` OK.
+
+## Phase 2 — Backend wiring (branche `feat/analysis-funnel-v2-backend`)
+
+Lancée après validation visuelle Phase 1. Les 2 PRs mergées ensemble à la fin.
+
+### Scope Phase 2
+
+1. **Meta Pixel dédié soumissionconfort**
+   - Nouvelles env vars : `NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT`, `META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT`, `META_TEST_EVENT_CODE_SOUMISSIONCONFORT`.
+   - Garde-fou runtime : si placeholder `XXXXXX` → skip CAPI + warn console.
+   - Migrer `app/layout.tsx`, `lib/meta-config.ts`, `app/api/leads/route.ts`, `app/api/test-meta`, `app/api/test-purchase`.
+   - Documenter dans `ENV_VARIABLES.md`.
+
+2. **Gating qualifié/curieux côté pixel (cf P1-4)**
+   - Retirer browser `Lead` du wizard.
+   - Browser `Lead` fire APRÈS OTP confirmé (ou après `/api/leads` ok si OTP off), gated par `intent === 'qualified'`.
+   - Server CAPI `Lead` : gate les 2 branches `/api/leads` par `intent === 'qualified'`.
+   - `PageView` + `ViewContent` pour tous. Nouvel endpoint `POST /api/meta/view-content` pour dedup CAPI.
+   - Retirer `CompleteRegistration` track (grep le repo).
+
+3. **GHL routing par tag**
+   - Nouveaux tags : `Lead Iso Hot` (qualifié) / `Lead Iso Curieux` (curieux) selon `intent`.
+   - Zack crée le stage "new lead hot" **manuellement dans l'UI GHL**.
+   - Workflows GHL ajustés par Zack pour router selon tag.
+   - **Pas d'appel direct `/opportunities`**.
+
+4. **Custom fields GHL — décision à prendre (cf P1-2)**
+   - Recommandation : option (a) — fields dédiés `symptoms`, `hydro_bracket`, `intent` via script gen.
+
+5. **Estimation gating dans la page finale**
+   - Sur `InsulationResults` ou `/pricing` : gater une ligne de copy selon intent. Qualifié = "On contacte 3 entrepreneurs". Curieux = "Voici ton estim, contacte-nous quand tu veux".
+
+### Tests Phase 2
+
+1. Lead qualifié → Events Manager : PageView + ViewContent + Lead reçus. EventID dedupé browser/CAPI.
+2. Lead curieux → PageView + ViewContent seulement. Pas de Lead.
+3. GHL : tags appliqués correctement, workflow GHL route vers bon stage.
+4. Custom fields GHL remplis avec V2 values (pas V1 defaults).
+5. OTP enabled : Lead pixel fire APRÈS OTP confirmé.
+6. `CompleteRegistration` complètement retiré.
+
+## Critical files (référence rapide)
+
+- [components/user-questionnaire-wizard.tsx](soumissionconfort/components/user-questionnaire-wizard.tsx) — wizard à refondre (544 → ~350 lignes attendues, sans popup)
+- [components/lead-capture-form.tsx](soumissionconfort/components/lead-capture-form.tsx) — refonte complète (176 lignes actuelles)
+- [components/lead-capture-popup.tsx](soumissionconfort/components/lead-capture-popup.tsx) — **ne pas supprimer** (utilisé par /thermopompes)
+- [components/insulation-results.tsx](soumissionconfort/components/insulation-results.tsx) — **pas toucher**
+- [app/analysis/page.tsx](soumissionconfort/app/analysis/page.tsx) — state machine (339 lignes)
+- [app/api/leads/route.ts](soumissionconfort/app/api/leads/route.ts) — Phase 1 = pas touché ; Phase 2 = gating intent + nouveaux fields
+- [lib/insulation-calculator.ts](soumissionconfort/lib/insulation-calculator.ts) — **pas toucher Phase 1** (mapping V2→V1 dans LeadCaptureForm)
+- [lib/ghl-fields-iso.ts](soumissionconfort/lib/ghl-fields-iso.ts) — Phase 2
+- [lib/ghl-client.ts](soumissionconfort/lib/ghl-client.ts) — Phase 2
+- [lib/meta-config.ts](soumissionconfort/lib/meta-config.ts) — Phase 2
+
+## Verification end-to-end
+
+**Phase 1 (visuel) — preview Vercel** :
+- [ ] Funnel complet homepage → pricing en ≤4 clicks après roof-analysis (Q1 → Q2 → Q3 → lead form → estimation).
+- [ ] Design identique aux screenshots de référence.
+- [ ] Multi-select Q1 : bouton "Suivant" disabled tant qu'aucune coche.
+- [ ] Auto-advance Q2 et Q3 avec click guard (pas de double-fire).
+- [ ] Bouton "Précédent" garde les réponses précédentes ; disabled sur Q1.
+- [ ] Address manquante dans URL → redirect homepage.
+- [ ] Pricing 3-tier `InsulationResults` s'affiche correctement (avec valeurs basées sur V1 defaults + V2 mapping symptoms).
+- [ ] `/thermopompes`, `/subventions`, `/soumission-rapide` : aucune régression.
+- [ ] `npx tsc --noEmit` et `npm run build` clean.
+- [ ] Plan commité au repo (`PLAN_FUNNEL_V2_ANALYSIS.md`).
+
+**Phase 2 (backend)** :
+- [ ] Test Events Manager Meta : Lead seulement pour qualifié, PageView + ViewContent pour tous.
+- [ ] GHL : tags + custom fields V2 + stage routing par workflow.
+- [ ] `CompleteRegistration` retiré.
+- [ ] OTP enabled : Lead pixel fire APRÈS OTP.
+
+**Merge final** :
+- [ ] PR Phase 1 + PR Phase 2 review Claude + Codex (`/commit-push-pr`).
+- [ ] Pixel Meta soumissionconfort créé, env vars updated Vercel.
+- [ ] Stage "new lead hot" créé manuellement GHL.
+- [ ] Merge des 2 PRs main → deploy prod → vérifier 1 lead réel (qualifié + curieux).
+
+## Questions ouvertes pour Zack
+
+1. **P2-2 — Photo background Q1** : tu veux une image en fond du wizard ? Si oui, source de l'asset ? (Le wizard actuel n'en a pas, les screenshots ne sont pas représentatifs du code actuel.)
+2. **P1-2 — GHL custom fields Phase 2** : tu préfères (a) créer 3 nouveaux fields dédiés `symptoms` / `hydro_bracket` / `intent`, (b) reuser `problemes_identifies` TEXT pour symptoms + créer 2 fields, ou (c) un super-field JSON ?
+3. **P0-3 — Pricing dégradation acceptée Phase 1** : le pricing 3-tier va devenir générique sur les axes chauffage/isolation/accès car ces champs sont supprimés du wizard. Acceptable pour Phase 1, ou tu veux Phase 1.5 qui étend `calculateInsulationPricing` pour utiliser symptoms+hydro comme inputs réels avant le merge prod ?

--- a/PLAN_FUNNEL_V2_PHASE2.md
+++ b/PLAN_FUNNEL_V2_PHASE2.md
@@ -1,0 +1,875 @@
+# Plan — Phase 2 funnel V2 `/analysis` (Backend wiring)
+
+> **Statut** : Phase 1 (visuel) mergée dans PR #20. Phase 2 ouvre une nouvelle branche `feat/analysis-funnel-v2-backend` **depuis** `feat/analysis-funnel-v2` (pas `main`). Les 2 PRs sont mergées ensemble à la fin.
+
+## Context
+
+Phase 1 a livré le wizard V2 (3 questions : symptoms / hydroBracket / intent), le lead form full-page, et le payload backward-compatible vers `/api/leads`. Les 3 champs V2 voyagent déjà dans `userAnswersPayload` mais GHL ne les écrit pas (les clés non mappées sont silencieusement ignorées avec un `console.warn`) et Meta reçoit un `Lead` indistinct pour qualifiés et curieux.
+
+**Phase 2 ferme la boucle, isolément sur le funnel `/analysis`**. Les autres funnels (`/thermopompes`, `/subventions`, `/soumission-rapide`) ne sont **pas touchés** : ils continuent sur le pixel partagé actuel, et leur logique GHL/CAPI reste intacte.
+
+### Schéma visuel — flux Meta du funnel `/analysis` (Phase 2 v2)
+
+**Vocabulaire d'abord** :
+
+| Terme technique | En langage clair |
+|---|---|
+| **Pixel actuel** (Niku setup) | Le tracker Meta unique en place aujourd'hui, partagé entre tous les funnels. Sert toujours homepage/thermopompes/subventions/soumission-rapide. **Désactivé sur `/analysis*` + `/verifier-telephone`.** |
+| **Pixel dédié soumissionconfort** | Le NOUVEAU tracker Meta. Chargé UNIQUEMENT sur le funnel /analysis. C'est lui qui devient ton "compteur de leads isolation" propre dans Meta Ads. |
+| **Browser event** (`fbq`) | Le code JS dans le navigateur qui ping Meta directement. Avantage : capture cookies Facebook attribution. Inconvénient : ad blockers le tuent. |
+| **CAPI event** (server-side) | Notre serveur Vercel qui ping Meta directement. Avantage : pas d'ad blocker. Inconvénient : pas de cookies attribution. |
+| **eventID partagé** | Browser + CAPI envoyés avec le même identifiant unique → Meta dedupe et compte 1 event. |
+| **PageView** | Event "le user a vu la page". Auto-envoyé par fbq à chaque chargement. |
+| **ViewContent** | Event "le user a vu un contenu spécifique". Manuel. Phase 2 : déclenché au mount du wizard `/analysis`. |
+| **Lead** | Event "le user est devenu un lead qualifié pour mon business". Meta optimise les Ads dessus. Précieux. Phase 2 : déclenché APRÈS OTP confirmé, qualifié uniquement. |
+
+---
+
+### Étape 1 — User sur la homepage
+
+```
+USER ouvre soumissionconfort.com/
+   │
+   │  Code : <MetaPixelRouter /> détecte pathname = "/"
+   │         → charge le PIXEL ACTUEL (Niku)
+   │  Code : fbq('init', 'PIXEL_ACTUEL_ID')
+   │  Code : fbq('track', 'PageView')   ← auto au chargement
+   │
+   ▼
+[Pixel actuel] envoie à Meta : PageView (page = "/")
+[Pixel dédié]  ← PAS chargé, ne reçoit rien
+```
+
+**En clair** : Comme aujourd'hui. Le pixel actuel voit la homepage. Le pixel dédié dort.
+
+---
+
+### Étape 2 — User entre son adresse et clique "Obtenir mon estimation"
+
+```
+USER tape son adresse → click "Obtenir mon estimation gratuite"
+   │
+   │  Code dans navigateToAnalysis() :
+   │   - router.push('/analysis?address=...')
+   │  (PAS de ViewContent ici — Phase 2 v2 le déplace au mount du wizard)
+   │
+   ▼
+USER navigue vers /analysis
+[Pixel actuel] ← rien envoyé (pas de fbq.track manuel ici)
+[Pixel dédié]  ← rien envoyé (pas encore chargé)
+```
+
+**En clair** : Le click ne déclenche aucun event spécifique. On laisse Next.js naviguer vers `/analysis`.
+
+---
+
+### Étape 3 — User arrive sur /analysis (loading + wizard)
+
+```
+USER arrive sur /analysis?address=...
+   │
+   │  Code : <MetaPixelRouter /> détecte pathname = "/analysis"
+   │         → DÉCHARGE le pixel actuel (script change)
+   │         → charge le PIXEL DÉDIÉ
+   │  Code : fbq('init', 'PIXEL_DEDIE_ID')
+   │  Code : fbq('track', 'PageView')   ← auto au chargement
+   │
+   ▼
+[Pixel actuel] ← reçoit RIEN (script remplacé, pas de re-fire)
+[Pixel dédié]  ← PageView (page = "/analysis?address=…")
+
+   │  Page : state = 'loading' → fetch /api/roof-analysis → response OK
+   │  Page : state = 'questionnaire' → wizard mount
+   │
+   │  Code (NOUVEAU au mount wizard) :
+   │   1. Génère eventID = "X"
+   │   2. fbq('track', 'ViewContent', {...}, {eventID: 'X'})
+   │        → envoie au [Pixel dédié] (le seul chargé)
+   │   3. fetch POST /api/meta/view-content { eventId: 'X' }
+   │        → server : metaAPI.trackViewContent vers [Pixel dédié] CAPI
+   │
+   ▼
+[Pixel dédié] reçoit ViewContent [X] 2 fois : browser + CAPI → dedup = 1
+
+USER fait Q1 symptoms → Q2 hydro → Q3 intent (qualifié OU curieux)
+   │
+   │  (rien envoyé à Meta pendant les questions — pas besoin)
+   │
+   ▼
+USER arrive au lead form
+```
+
+**En clair** :
+- Dès qu'on arrive sur `/analysis`, Next.js change le pixel chargé : il vire le pixel actuel et met le pixel dédié à la place. Audience pixel actuel = ne voit jamais `/analysis`.
+- Au mount du wizard (après le loading), on envoie un ViewContent au pixel dédié. Browser + CAPI tous deux avec le même eventID = Meta compte 1 event "ce user a commencé l'application".
+
+---
+
+### Étape 4 — User soumet le lead form
+
+```
+USER click "Découvrir mon estimation maintenant"
+   │
+   │  Code : Génère un eventID = "Y" (nouveau, différent de X)
+   │  Code : stash sessionStorage.pending-lead = {
+   │            firstName, lastName, ..., eventId: 'Y',
+   │            meta: { intent: 'qualified' OU 'curious', estimatedValue: 1200 }
+   │          }
+   │  Code : router.push('/verifier-telephone')
+   │
+   │  ⚠️ PAS de fbq('Lead') ici. Phase 2 le déplace après l'OTP confirmé.
+   │
+   ▼
+USER navigue vers /verifier-telephone (SMS code)
+```
+
+**En clair** : On garde l'info dans le navigateur du user (sessionStorage), on l'envoie sur la page OTP. **On n'envoie PAS encore l'event Lead à Meta**. On attend la preuve que le téléphone existe vraiment (sinon on déclarerait des leads bidon).
+
+---
+
+### Étape 5 — User confirme l'OTP par SMS
+
+```
+USER tape le code 6 chiffres → submit
+   │
+   │  Code : POST /api/verify-otp → twilio confirme → ok
+   │  Code : submitDeferredLead() → POST /api/leads avec le payload complet
+   │         { firstName, ..., eventId: 'Y', userAnswers: { intent: '...' } }
+   │
+   │  SERVER /api/leads fait 2 trucs :
+   │  ┌──────────────────────────────────────────────────────────┐
+   │  │ A) GHL (toujours, peu importe l'intent) :                │
+   │  │    - crée/upsert le contact dans le sub-account Iso       │
+   │  │    - écrit les custom fields (symptoms, hydro, intent)    │
+   │  │    - applique tag 'Lead Iso Hot' si qualifié              │
+   │  │                       OU 'Lead Iso Curieux' si curieux    │
+   │  │    - DELETE 'Lead Iso Curieux' si user était déjà         │
+   │  │      curieux + se requalifie (override)                   │
+   │  │                                                            │
+   │  │ B) Meta CAPI (CONDITIONNEL selon intent) :                │
+   │  │    SI intent === 'qualified' :                            │
+   │  │       metaAPI.trackLead({ eventId: 'Y', value: ... })    │
+   │  │       → envoie à [Pixel dédié] : Lead [Y] qualifié        │
+   │  │    SI intent === 'curious' :                              │
+   │  │       skip — RIEN envoyé à Meta                           │
+   │  └──────────────────────────────────────────────────────────┘
+   │
+   │  Côté CLIENT, après que /api/leads retourne OK :
+   │  ┌──────────────────────────────────────────────────────────┐
+   │  │ Code dans /verifier-telephone (route group analysis-funnel│
+   │  │ → pixel dédié toujours chargé via MetaPixelRouter) :     │
+   │  │ SI pending.meta.intent === 'qualified' :                 │
+   │  │    fbq('track', 'Lead', { value, currency }, {           │
+   │  │       eventID: 'Y'   ← MÊME eventID que CAPI = dedup     │
+   │  │    })                                                     │
+   │  │    → envoie au [Pixel dédié] (le seul chargé)            │
+   │  │ SI intent === 'curious' :                                │
+   │  │    skip — RIEN envoyé à Meta                             │
+   │  └──────────────────────────────────────────────────────────┘
+   │
+   ▼
+[Pixel dédié]  reçoit Lead [Y] 2 fois : browser + CAPI → Meta dedupe = 1 Lead
+[Pixel actuel] reçoit RIEN (pas chargé sur /verifier-telephone)
+```
+
+**En clair** :
+- **Lead qualifié confirmé OTP** → Meta reçoit l'event Lead 2x sur le pixel dédié (1x du navigateur + 1x de notre serveur), avec le même identifiant Y. Meta voit "c'est le même event, je compte 1 lead". Audience pixel dédié = clean.
+- **Lead curieux confirmé OTP** → Meta ne reçoit RIEN comme Lead. GHL reçoit quand même le contact (tag `Lead Iso Curieux`). Tu pourras le travailler en sales follow-up mais Meta n'optimise pas ses ads dessus → tu paies pas pour aller chercher d'autres curieux.
+
+---
+
+### Étape 6 — Redirection vers la page d'estimation
+
+```
+USER arrive sur /pricing?leadId=...&d=...
+   │
+   │  Code : MetaPixelRouter détecte pathname = "/pricing"
+   │         → DÉCHARGE le pixel dédié
+   │         → charge le pixel actuel
+   │  Code : fbq('init', 'PIXEL_ACTUEL_ID')
+   │  Code : fbq('track', 'PageView')
+   │
+   ▼
+[Pixel actuel] ← PageView (/pricing)
+[Pixel dédié]  ← démonté
+[Page] → affiche InsulationResults (même copy pour qualifié et curieux)
+```
+
+**En clair** : Le user a vu son estimation. Le pixel dédié dort. Le pixel actuel reprend le contrôle pour le reste du site.
+
+---
+
+### Récap "qui a vu quoi dans Meta" en fin de funnel
+
+| Lead type | Pixel actuel (Niku) voit | Pixel dédié soumissionconfort voit |
+|---|---|---|
+| **Qualifié** | PageView homepage, PageView /pricing | PageView /analysis, **ViewContent [X]**, PageView /verifier-telephone, **Lead [Y] dedupé** |
+| **Curieux** | PageView homepage, PageView /pricing | PageView /analysis, **ViewContent [X]**, PageView /verifier-telephone (PAS de Lead) |
+
+**La grande différence** : le pixel dédié voit **uniquement le funnel /analysis**, et il ne reçoit un Lead **que pour les qualifiés post-OTP**. Audience pixel dédié = 100% propre. Le pixel actuel ne voit jamais le funnel `/analysis` — pas de bruit, ses audiences thermopompes/subventions/soumission-rapide restent intactes.
+
+### Logique du pixel actuel (Niku) vs pixel dédié — résumé (Zack tranché v2)
+
+- **Pixel actuel** (`NEXT_PUBLIC_META_PIXEL_ID`, setup Niku, partagé) :
+  - Continue de servir homepage `/`, `/thermopompes`, `/subventions`, `/soumission-rapide`.
+  - Sur `/analysis*` et `/verifier-telephone` → **désactivé** (ne se charge pas, ne fire rien). Aucun bruit isolation dans son audience.
+- **Pixel dédié soumissionconfort** (`NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT`, NOUVEAU) :
+  - Chargé **uniquement** sur `/analysis*` et `/verifier-telephone`.
+  - Reçoit : PageView (auto au mount), ViewContent (au mount du wizard), Lead (post-OTP qualifié uniquement, browser + CAPI dedup).
+  - Audience clean isolation → utilisable pour optimiser tes campagnes Ads Meta sur les leads qualifiés iso.
+
+### Logique de décision du Lead — résumé
+
+Le pixel **Lead** est envoyé à Meta **uniquement si les 3 conditions sont réunies** (mot-à-mot Zack, validé) :
+
+1. **À la question d'intent** (= Q3 du wizard, ou "Q4" si on compte l'adresse comme Q1) le user a sélectionné **"Je veux faire les travaux"** (`intent = 'qualified'`).
+2. Le user a **soumis le form de contact** (prénom + nom + email + téléphone).
+3. Le user a **confirmé le code SMS** sur `/verifier-telephone` (OTP_ENABLED=true en prod).
+
+Si **n'importe laquelle** des 3 conditions manque → **aucun Lead envoyé à Meta** (ni browser, ni CAPI, ni au pixel global, ni au pixel dédié). Le contact est quand même créé dans GHL (avec son tag `Lead Iso Curieux` si curieux, ou pas de contact du tout si abandon).
+
+### Sequence d'events Meta cible (mot pour mot Zack)
+
+1. **PageView** → fire automatiquement par le tag du pixel sur chaque navigation (déjà géré par `app/layout.tsx`). **On n'y touche pas.**
+2. **ViewContent** → **NOUVEAU** : fire **quand l'utilisateur soumet son adresse depuis le homepage** (dans `navigateToAnalysis()` de [app/page.tsx:81-94](soumissionconfort/app/page.tsx#L81-L94), juste avant `router.push(href)`). Signal Meta : « ce user a commencé l'application ». Browser pixel + CAPI dedup via `eventID`.
+3. **Lead** → fire **uniquement si `intent === 'qualified'`** APRÈS confirmation OTP (path OTP_ENABLED=true) **ou** APRÈS retour `/api/leads` OK (path OTP off). Curieux → aucun Lead, ni browser ni CAPI.
+
+### GHL cible
+
+- Écrire les 3 V2 fields (`symptoms`, `hydro_bracket`, `intent`) dans le contact GHL (les IDs existent déjà dans `lib/ghl-fields-iso.ts` lignes 41-43).
+- Remplacer le tag statique `Lead Iso` par **`Lead Iso Hot`** (qualifié) ou **`Lead Iso Curieux`** (curieux) sur le contact isolation.
+- Si un contact existant a déjà `Lead Iso Curieux` et revient en qualifié → **ajouter `Lead Iso Hot` ET retirer `Lead Iso Curieux`** (override). On garde une seule "vérité" : le statut le plus chaud.
+
+### Cleanup
+
+- Retirer le seul `fbq("track", "CompleteRegistration", ...)` (dans [app/soumission-rapide/merci/page.tsx:72](soumissionconfort/app/soumission-rapide/merci/page.tsx#L72)). Demande explicite plan source P1-4. Funnel inactif → impact prod nul, mais cleanup propre.
+
+---
+
+## État actuel vérifié
+
+- `feat/analysis-funnel-v2` est checked out, PR #20 ouverte. 3 GHL custom fields créés dans sub-account Iso `7gpshI6Ger307wy0gSRU` ([lib/ghl-fields-iso.ts:41-43](soumissionconfort/lib/ghl-fields-iso.ts#L41-L43)).
+- [components/lead-capture-form.tsx:124-137](soumissionconfort/components/lead-capture-form.tsx#L124-L137) fire déjà `fbq('Lead', ...)` browser gated par `intent === 'qualified'` — **à déplacer post-OTP**.
+- [app/api/leads/route.ts:269-321](soumissionconfort/app/api/leads/route.ts#L269-L321) (branche GHL) appelle `metaAPI.trackLead()` **sans gate intent** — à gater + à pointer vers le nouveau pixel.
+- [app/api/leads/route.ts:747-819](soumissionconfort/app/api/leads/route.ts#L747-L819) (branche legacy Make) — pas exécutée en prod (`GHL_ENABLED=true`). On la gate par cohérence mais pas une priorité.
+- [lib/meta-config.ts](soumissionconfort/lib/meta-config.ts) expose `META_CONFIG` partagé. Ajouter `META_CONFIG_SOUMISSIONCONFORT` à côté (cohabitation, pas remplacement).
+- [lib/meta-conversion-api.ts:101-119](soumissionconfort/lib/meta-conversion-api.ts#L101-L119) `trackViewContent` existe mais **ne supporte pas `eventId`** → dedup browser/CAPI impossible tel quel. À étendre.
+- [app/page.tsx:75-79](soumissionconfort/app/page.tsx#L75-L79) appelle déjà `trackViewContent('Homepage', 'website')` au mount — c'est un autre event (Homepage view), **on le garde**. Le nouveau ViewContent (au submit adresse, `analysis-wizard-v2`) s'ajoute à côté avec un `content_name` distinct.
+- [app/page.tsx:81-94](soumissionconfort/app/page.tsx#L81-L94) `navigateToAnalysis()` = le point d'injection ViewContent demandé par Zack.
+- [app/soumission-rapide/merci/page.tsx:72](soumissionconfort/app/soumission-rapide/merci/page.tsx#L72) : seule occurrence `CompleteRegistration` (grep confirmé).
+- [app/verifier-telephone/page.tsx:99-127](soumissionconfort/app/verifier-telephone/page.tsx#L99-L127) — `submitDeferredLead()` POST `/api/leads`. Le browser Lead fire ici après `submitDeferredLead` OK.
+- `GHL_ENABLED=true` en prod (vérifié dans le code et la doc).
+- GHL API `DELETE /contacts/{contactId}/tags` confirmé existant (doc officielle). Body `{ tags: [string] }` par cohérence avec ADD (le body schema exact n'est pas documenté côté Remove, à valider en preview avec un curl test).
+
+---
+
+## Phase 2.0 — Setup branche
+
+```
+git checkout feat/analysis-funnel-v2
+git pull
+git checkout -b feat/analysis-funnel-v2-backend
+git branch --show-current  # confirmer feat/analysis-funnel-v2-backend
+```
+
+Pixel ID + token Meta : **Zack écrit directement dans `.env.local`** (et plus tard dans Vercel) — pas dans le chat. Le code accepte un placeholder `XXXXXX` avec garde-fou (skip silencieux + `console.warn`).
+
+---
+
+## Phase 2.1 — Pixel Meta dédié soumissionconfort, scope = `/analysis` uniquement
+
+### Nouvelles env vars
+
+```bash
+NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT=<pixel ID Meta>
+META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT=<token CAPI Meta>
+META_TEST_EVENT_CODE_SOUMISSIONCONFORT=  # optionnel pour tests
+```
+
+Les vars existantes (`NEXT_PUBLIC_META_PIXEL_ID`, `META_CONVERSION_ACCESS_TOKEN`) **restent** et continuent à servir les autres funnels (homepage PageView, thermopompes, subventions, soumission-rapide).
+
+### Fichier modifié : [lib/meta-config.ts](soumissionconfort/lib/meta-config.ts)
+
+Ajouter à côté du `META_CONFIG` existant :
+
+```ts
+export const META_CONFIG_SOUMISSIONCONFORT = {
+  PIXEL_ID: process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT || '',
+  ACCESS_TOKEN: process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT || '',
+  TEST_EVENT_CODE: process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT || undefined,
+}
+
+export function isSoumissionConfortMetaConfigured(): boolean {
+  const id = META_CONFIG_SOUMISSIONCONFORT.PIXEL_ID
+  const token = META_CONFIG_SOUMISSIONCONFORT.ACCESS_TOKEN
+  if (!id || !token) return false
+  // Garde-fou placeholder XXXXXX
+  if (/^X+$/i.test(id) || /^X+$/i.test(token)) return false
+  return true
+}
+```
+
+### Décision portée du pixel browser (Zack tranché v2)
+
+**Sur les routes du funnel `/analysis`** (= `/analysis`, `/analysis/*`, `/verifier-telephone`) :
+- Le pixel **actuel partagé** (celui setup par Niku, `NEXT_PUBLIC_META_PIXEL_ID`) est **DÉSACTIVÉ** — il ne reçoit aucun event de ce funnel.
+- Seul le **pixel dédié soumissionconfort** est chargé et reçoit les events.
+- Résultat : audience pixel dédié 100% propre (uniquement isolation /analysis), pixel actuel continue de servir thermopompes/subventions/soumission-rapide comme avant, sans bruit iso.
+
+### Comment désactiver le pixel actuel sur `/analysis*` + `/verifier-telephone`
+
+Le pixel actuel est chargé dans [app/layout.tsx](soumissionconfort/app/layout.tsx) (root, Server Component qui ne peut pas utiliser `usePathname`). On ne peut pas conditionner directement le `<Script>` dans ce layout.
+
+**Solution** : extraire la logique pixel dans un **client component intelligent** qui décide quel pixel charger selon le pathname.
+
+#### Nouveau composant : [components/meta-pixel-router.tsx](soumissionconfort/components/meta-pixel-router.tsx)
+
+```tsx
+"use client"
+import Script from 'next/script'
+import { usePathname } from 'next/navigation'
+
+const PIXEL_PARTAGE = process.env.NEXT_PUBLIC_META_PIXEL_ID
+const PIXEL_DEDIE = process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT
+
+function isAnalysisFunnel(pathname: string): boolean {
+  return pathname === '/analysis'
+    || pathname.startsWith('/analysis/')
+    || pathname === '/verifier-telephone'
+}
+
+export function MetaPixelRouter() {
+  const pathname = usePathname()
+  const inAnalysisFunnel = isAnalysisFunnel(pathname)
+
+  // Décide quel pixel ID charger
+  const pixelToLoad = inAnalysisFunnel ? PIXEL_DEDIE : PIXEL_PARTAGE
+
+  // Garde-fou strict (Zack v2 décision 5) :
+  // - Si on est dans le funnel /analysis ET le pixel dédié est placeholder XXXXXX
+  //   → return null (PAS de fallback vers le pixel actuel — audience pure).
+  // - Si on est sur les autres pages ET le pixel actuel est placeholder
+  //   → return null aussi (pas de tracking, mais ça n'arrive pas en prod).
+  if (!pixelToLoad || /^X+$/i.test(pixelToLoad)) return null
+
+  return (
+    <>
+      <Script id="meta-pixel" strategy="afterInteractive">
+        {`
+          !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+          n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+          n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+          document,'script','https://connect.facebook.net/en_US/fbevents.js');
+          fbq('init', '${pixelToLoad}');
+          fbq('track', 'PageView');
+        `}
+      </Script>
+      <noscript>
+        <img height="1" width="1" style={{ display: 'none' }}
+          src={`https://www.facebook.com/tr?id=${pixelToLoad}&ev=PageView&noscript=1`} alt="" />
+      </noscript>
+    </>
+  )
+}
+```
+
+#### Modification : [app/layout.tsx](soumissionconfort/app/layout.tsx)
+
+Retirer le `<Script>` du pixel actuel (lignes 166-195) et remplacer par :
+```tsx
+<MetaPixelRouter />
+```
+
+**Conséquence** :
+- Sur `/`, `/thermopompes`, `/subventions`, `/soumission-rapide` etc. → `MetaPixelRouter` charge le **pixel actuel partagé**. Comportement identique à aujourd'hui.
+- Sur `/analysis*` et `/verifier-telephone` → `MetaPixelRouter` charge le **pixel dédié soumissionconfort** UNIQUEMENT. Le pixel actuel ne se charge même pas, ne fire rien.
+
+**Trade-off à comprendre** :
+- Quand un user navigue depuis homepage `/` (pixel partagé chargé) vers `/analysis` (pixel dédié chargé) : Next.js fait une nav SPA → le composant `MetaPixelRouter` reste mounté mais son contenu change. Le `<Script>` change de pixel ID → fbq se ré-init avec le nouveau pixel. **Le PageView de `/analysis` part donc uniquement au pixel dédié, pas au pixel partagé. C'est exactement ce qu'on veut.**
+- Quand un user clique "Obtenir mon estimation" sur la homepage → l'event ViewContent (que Phase 2 ajoute dans `navigateToAnalysis`) fire **sur la homepage** au moment du click, donc avant que la navigation se termine, donc le `fbq('track','ViewContent',...)` part **au pixel partagé**, PAS au pixel dédié. **Problème** : le pixel dédié manque le ViewContent du submit adresse depuis homepage.
+
+#### Sous-problème : ViewContent depuis homepage doit aller au pixel dédié
+
+Le ViewContent au submit adresse depuis homepage **doit** être attribué au pixel dédié soumissionconfort (pas au pixel actuel partagé). Mais à ce moment, le navigateur n'a chargé que le pixel partagé (puisque l'utilisateur est sur `/` qui n'est pas dans le funnel `/analysis`).
+
+**Options** :
+
+1. **Inversion : déclencher le ViewContent côté serveur uniquement** (pas de `fbq('track', 'ViewContent')` browser depuis homepage). Le `fetch /api/meta/view-content` du serveur envoie le ViewContent au pixel dédié via CAPI. **Inconvénient** : pas d'attribution Facebook cookies (`_fbp`/`_fbc`) côté browser → Meta a moins de signal pour l'attribution. Mais c'est mieux que d'envoyer au mauvais pixel.
+
+2. **Fire le ViewContent browser depuis `/analysis` au mount du wizard** (pas depuis homepage au submit adresse). Le pixel dédié est chargé à ce moment-là, donc browser fbq + CAPI vont tous deux au bon pixel.
+
+**Décision recommandée Option 2** : déplacer le déclencheur ViewContent **du homepage submit adresse → vers le mount du wizard `/analysis`**. C'est très proche de l'intention Zack ("quand il commence à remplir") — l'arrivée sur le wizard = effectivement quand le user commence à interagir avec le funnel. Différence : retard d'environ 1-3 secondes (le temps du `/api/roof-analysis`). Pas critique pour Meta.
+
+**À confirmer avec Zack** : OK pour fire ViewContent au mount `/analysis` (= juste après loading roof-analysis, avant Q1) plutôt qu'au submit adresse homepage ?
+
+**Note** : la décision verrouillée (Zack v2) impose que le pixel actuel soit DÉSACTIVÉ sur `/analysis*` + `/verifier-telephone`. La solution `<MetaPixelRouter />` ci-dessus (avant la sequence visuelle) couvre cette logique : un composant unique qui charge soit l'un soit l'autre selon `usePathname()`. Pas besoin de route group `(analysis-funnel)` pour ça — `<MetaPixelRouter />` est monté dans `app/layout.tsx` une seule fois, il gère lui-même la bascule sur navigation.
+
+---
+
+## Phase 2.2 — ViewContent fire au mount /analysis (après loading roof-analysis)
+
+**Décision Zack v2** : le ViewContent doit aller **au pixel dédié** uniquement, pas au pixel actuel. Mais le pixel dédié n'est pas chargé sur la homepage (`MetaPixelRouter` charge le pixel actuel sur `/`). Si on fire ViewContent au submit homepage, l'event browser part au pixel actuel = pollution. **Donc on déménage le déclencheur du submit adresse → vers le mount du wizard `/analysis`**.
+
+**Conséquence** : `app/page.tsx` ligne 81-94 (`navigateToAnalysis`) ne reçoit pas de nouveau code pour ViewContent. Aucune modification de la homepage (sauf garder l'`trackViewContent('Homepage'…)` mount existant ligne 77).
+
+### Fichier modifié : [components/user-questionnaire-wizard.tsx](soumissionconfort/components/user-questionnaire-wizard.tsx)
+
+Ajout d'un `useEffect` fire-once au mount du wizard (= moment où le wizard apparaît après le loading roof-analysis) :
+
+```tsx
+const viewContentFiredRef = useRef(false)
+useEffect(() => {
+  if (viewContentFiredRef.current) return
+  viewContentFiredRef.current = true
+
+  const eventId = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `vc-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+  // Browser pixel ViewContent (vers le pixel dédié, déjà chargé sur /analysis via MetaPixelRouter)
+  if (typeof window !== 'undefined' && typeof window.fbq === 'function') {
+    window.fbq('track', 'ViewContent', {
+      content_name: 'analysis-wizard-v2',
+      content_category: 'isolation',
+    }, { eventID: eventId })
+  }
+
+  // CAPI ViewContent vers le pixel dédié soumissionconfort (dedup via même eventId)
+  fetch('/api/meta/view-content', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      eventId,
+      sourceUrl: typeof window !== 'undefined' ? window.location.href : undefined,
+    }),
+    keepalive: true,
+  }).catch(err => console.warn('ViewContent CAPI failed', err))
+}, [])
+```
+
+**Pourquoi le wizard et pas `/analysis/page.tsx`** : le wizard ne se mount que quand `currentStep === 'questionnaire'` (donc après le loading roof-analysis OK). Si on monte le useEffect dans `page.tsx`, le ViewContent fire dès le state 'loading' → trop tôt (l'utilisateur n'a pas encore "commencé l'application"). Le wizard mount = exactement le moment voulu par Zack.
+
+**`keepalive: true`** : conservé même si pas strictement nécessaire ici (le user reste sur la page après le mount, pas de navigation immédiate). Bonne hygiène défense au cas où le user click rapidement quelque chose.
+
+### Nouveau fichier : [app/api/meta/view-content/route.ts](soumissionconfort/app/api/meta/view-content/route.ts)
+
+```ts
+import { NextRequest, NextResponse } from 'next/server'
+import { MetaConversionAPI } from '@/lib/meta-conversion-api'
+import { META_CONFIG_SOUMISSIONCONFORT, isSoumissionConfortMetaConfigured } from '@/lib/meta-config'
+
+export async function POST(request: NextRequest) {
+  if (!isSoumissionConfortMetaConfigured()) {
+    console.warn('[view-content] Meta CAPI not configured for soumissionconfort (skip)')
+    return NextResponse.json({ skipped: true })
+  }
+  try {
+    const { eventId, sourceUrl, address } = await request.json()
+    const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0]
+      || request.headers.get('x-real-ip') || 'unknown'
+    const userAgent = request.headers.get('user-agent') || 'unknown'
+
+    const metaAPI = new MetaConversionAPI(
+      META_CONFIG_SOUMISSIONCONFORT.PIXEL_ID,
+      META_CONFIG_SOUMISSIONCONFORT.ACCESS_TOKEN,
+      META_CONFIG_SOUMISSIONCONFORT.TEST_EVENT_CODE,
+    )
+
+    await metaAPI.trackViewContent({
+      eventId,
+      sourceUrl,
+      clientIp,
+      userAgent,
+      contentName: 'analysis-wizard-v2',
+      contentType: 'isolation',
+      searchString: address,
+    })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('[view-content] CAPI error', err)
+    return NextResponse.json({ ok: false }, { status: 500 })
+  }
+}
+```
+
+### Fichier modifié : [lib/meta-conversion-api.ts](soumissionconfort/lib/meta-conversion-api.ts)
+
+Refactor `trackViewContent` (lignes 101-119) pour accepter une signature object avec `eventId` :
+
+```ts
+async trackViewContent(data: {
+  contentName?: string
+  contentType?: string
+  searchString?: string
+  eventId?: string
+  clientIp?: string
+  userAgent?: string
+  sourceUrl?: string
+}) {
+  const userData: any = {}
+  if (data.clientIp) userData.client_ip_address = data.clientIp
+  if (data.userAgent) userData.client_user_agent = data.userAgent
+
+  const event: MetaConversionEvent = {
+    event_name: 'ViewContent',
+    event_id: data.eventId,
+    event_time: Math.floor(Date.now() / 1000),
+    action_source: 'website',
+    user_data: userData,
+    custom_data: {
+      content_type: data.contentType || 'website',
+      content_name: data.contentName || 'Homepage',
+      currency: 'CAD',
+      ...(data.searchString && { search_string: data.searchString }),
+    },
+    event_source_url: data.sourceUrl
+      || (typeof window !== 'undefined' ? window.location.href : undefined),
+  }
+  return this.sendEvent(event)
+}
+```
+
+**Backward compat** : l'appelant homepage existant ligne 77 (`trackViewContent('Homepage', 'website')`) appelle via la convenience function exportée ligne 343-349. Refactorer la convenience pour accepter soit la vieille signature `(contentName, contentType)` soit la nouvelle object, ou changer l'appelant homepage pour passer un objet. Plus simple : adapter [app/page.tsx:77](soumissionconfort/app/page.tsx#L77) à la nouvelle signature `trackViewContent({ contentName: 'Homepage', contentType: 'website' })`.
+
+---
+
+## Phase 2.3 — Lead event uniquement APRÈS OTP + intent qualifié
+
+### Fichier modifié : [components/lead-capture-form.tsx](soumissionconfort/components/lead-capture-form.tsx)
+
+**Retirer lignes 124-137** (le `window.fbq('track', 'Lead', ...)` actuel — il fire avant l'OTP).
+
+**Ajouter dans le `leadPayload` stashé** pour que `/verifier-telephone` puisse fire le Lead après OTP. **Important (P0-3)** : `leadPayload.eventId` existe DÉJÀ au top-level (ligne 119 actuelle) — c'est lui qu'on réutilise côté `/verifier-telephone` via `pending.eventId`. Ne PAS le déplacer dans `pending.meta`.
+
+```ts
+const leadPayload = {
+  // ... existant
+  eventId,  // déjà présent ligne 119 — reste top-level pour /verifier-telephone
+  meta: {
+    intent: v2Answers.intent,
+    estimatedValue: pricingData?.ranges?.standard
+      ? (pricingData.ranges.standard.totalCost.min + pricingData.ranges.standard.totalCost.max) / 2
+      : 0,
+  },
+}
+```
+
+**Path non-OTP (OTP_ENABLED=false)** : fire le Lead browser **APRÈS** `/api/leads` 200 (au lieu d'avant), gated par `qualified` + même `eventId` que CAPI. Localisation : après ligne 177 actuelle (`onComplete(...)`), juste avant.
+
+### Fichier modifié : [app/verifier-telephone/page.tsx](soumissionconfort/app/verifier-telephone/page.tsx)
+
+Dans `confirmOtp()`, après que `submitDeferredLead(data.otpToken)` retourne `{ ok: true }` (ligne 161) et avant `setState("verified")` ligne 183 :
+
+```ts
+try {
+  const pendingRaw = sessionStorage.getItem("pending-lead")
+  if (pendingRaw) {
+    const pending = JSON.parse(pendingRaw)
+    if (
+      pending?.meta?.intent === 'qualified' &&
+      typeof window !== 'undefined' &&
+      typeof window.fbq === 'function'
+    ) {
+      const eventId = pending.eventId
+        || ('randomUUID' in crypto ? crypto.randomUUID() : `lead-${Date.now()}`)
+      window.fbq('track', 'Lead', {
+        value: (pending.meta.estimatedValue || 0).toFixed(2),
+        currency: 'CAD',
+        service_type: 'isolation',
+      }, { eventID: eventId })
+    }
+  }
+} catch (err) {
+  console.warn('post-OTP Lead pixel failed', err)
+}
+```
+
+**Note dedup** : `pending.eventId` est exactement celui passé à `/api/leads` ligne 119 (`leadPayload.eventId`) → `metaAPI.trackLead({ eventId: leadData.eventId })` ligne 311 → Meta dedupe le Lead browser ↔ CAPI.
+
+### CAPI Lead — gating intent + pixel dédié
+
+#### Fichier modifié : [app/api/leads/route.ts](soumissionconfort/app/api/leads/route.ts)
+
+Branche GHL, lignes 269-321 : remplacer la sélection statique du pixel par une dispatch par vertical, + gate intent.
+
+```ts
+const useSoumissionConfortPixel = vertical === 'isolation'  // pas isolation_soumission_rapide — pas dans le scope V2
+const metaPixelId = useSoumissionConfortPixel
+  ? process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT
+  : process.env.NEXT_PUBLIC_META_PIXEL_ID
+const metaAccessToken = useSoumissionConfortPixel
+  ? process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT
+  : process.env.META_CONVERSION_ACCESS_TOKEN
+const metaTestEventCode = useSoumissionConfortPixel
+  ? process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT
+  : process.env.META_TEST_EVENT_CODE
+
+const isPlaceholder = (v?: string) => !!v && /^X+$/i.test(v)
+const intentGateOk = !useSoumissionConfortPixel
+  || leadData.userAnswers?.intent === 'qualified'
+const isTestLead = leadData.isTest === true  // gate replay/debug (Zack v2 décision 7)
+
+if (
+  !isTestLead
+  && metaPixelId && metaAccessToken
+  && !isPlaceholder(metaPixelId) && !isPlaceholder(metaAccessToken)
+  && intentGateOk
+) {
+  const metaAPI = initializeMetaConversionAPI(metaPixelId, metaAccessToken, metaTestEventCode)
+  // ... reste inchangé (trackLead existant)
+} else if (isTestLead) {
+  console.log('[leads] skip Meta CAPI Lead — isTest=true')
+} else if (useSoumissionConfortPixel && !intentGateOk) {
+  console.log('[leads] skip Meta CAPI Lead — intent !== qualified')
+} else if (useSoumissionConfortPixel && (isPlaceholder(metaPixelId) || isPlaceholder(metaAccessToken))) {
+  console.warn('[leads] skip Meta CAPI Lead — soumissionconfort pixel/token is placeholder XXXXXX')
+}
+```
+
+Branche legacy Make (lignes 747-819) : appliquer le même pattern par cohérence (même si pas exécutée en prod).
+
+---
+
+## Phase 2.4 — GHL : tag override + 3 V2 custom fields
+
+### Fichier modifié : [lib/ghl-client.ts](soumissionconfort/lib/ghl-client.ts)
+
+1. Étendre `NormalizedLead` interface (ligne 27-54) avec un champ optionnel :
+```ts
+tagOverride?: string         // remplace VERTICAL_TAG[vertical] si présent
+tagsToRemove?: string[]      // tags à retirer après upsert (best-effort)
+```
+
+2. Dans `buildContactPayload` ligne 154, utiliser l'override :
+```ts
+tags: [lead.tagOverride ?? VERTICAL_TAG[lead.vertical]],
+```
+
+3. Dans `postLeadToGHL` (ligne 227), après `created.body?.contact?.id`, ajouter la suppression de tags :
+```ts
+if (contactId && lead.tagsToRemove && lead.tagsToRemove.length > 0) {
+  // GHL DELETE /contacts/{id}/tags — best-effort, on log si fail mais on bloque pas
+  const removeRes = await ghlRequest(apiKey, `/contacts/${contactId}/tags`, {
+    method: 'DELETE',
+    body: JSON.stringify({ tags: lead.tagsToRemove }),
+  })
+  if (!removeRes.ok) {
+    console.warn(`[ghl-client] tag removal failed for ${contactId}:`, removeRes.error)
+  }
+}
+```
+
+**Note** : le body schema `{ tags: [...] }` pour DELETE est inféré par cohérence avec ADD. À valider en preview avec un test contact + curl avant prod. Si le body diffère, ajuster (Phase 2.4.b).
+
+### Fichier modifié : [app/api/leads/route.ts](soumissionconfort/app/api/leads/route.ts)
+
+**Lignes 204-230** (bloc `!isHVAC && !isSubvention && !isSoumissionRapide` = isolation V2) : ajouter les 3 fields V2 au mapping `custom` :
+
+```ts
+...(!isHVAC && !isSubvention && !isSoumissionRapide && {
+  // ... existant V1 fields conservés (backward compat)
+  // V2 fields — wired Phase 2 (IDs déjà dans GHL_FIELDS_ISO lignes 41-43)
+  symptoms: Array.isArray(leadData.userAnswers?.symptoms)
+    ? leadData.userAnswers.symptoms.join(',')
+    : leadData.userAnswers?.symptoms,
+  hydro_bracket: leadData.userAnswers?.hydroBracket,
+  intent: leadData.userAnswers?.intent,
+}),
+```
+
+**Avant `postLeadToGHL(ghlPayload)`** (ligne 249) : router le tag + planifier la suppression de l'opposé :
+
+```ts
+if (vertical === 'isolation' && leadData.userAnswers?.intent) {
+  if (leadData.userAnswers.intent === 'qualified') {
+    ghlPayload.tagOverride = 'Lead Iso Hot'
+    ghlPayload.tagsToRemove = ['Lead Iso Curieux']  // override : on retire l'ancien statut curieux si présent
+  } else if (leadData.userAnswers.intent === 'curious') {
+    ghlPayload.tagOverride = 'Lead Iso Curieux'
+    // Pas de tagsToRemove ici — si déjà qualifié, on garde Lead Iso Hot (downgrade vers curieux = rare et on préfère ne pas perdre l'info)
+  }
+}
+```
+
+> Edge case : si un contact qualifié revient et clique curieux → on garde `Lead Iso Hot` (pas de removal). Décision arbitraire (assomption : une fois qualifié, toujours qualifié). À discuter si Zack veut le comportement inverse.
+
+### Backward compat fields V1
+
+Les fields V1 (`isolation_actuelle`, `acces_entretoit`, `systeme_de_chauffage`, `problemes_identifies`) **continuent** d'être écrits avec leurs V1 defaults (Phase 1 a câblé `'electricite' / 'partielle' / 'facile'`). Les workflows GHL existants qui dépendent de ces champs ne cassent pas. Les nouveaux V2 fields s'ajoutent à côté.
+
+---
+
+## Traçabilité — chaque réponse du funnel V2 vers GHL (champ-par-champ)
+
+Confirmation explicite : chaque info que le user fournit dans le funnel `/analysis` a un chemin garanti vers GHL en Phase 2.
+
+| Étape | Question / Info | Variable code | Field GHL (sub-account Iso `7gpshI6Ger307wy0gSRU`) | Field ID | Comment écrit |
+|---|---|---|---|---|---|
+| **Homepage** | Adresse autocomplete | `address` (URL param) | `Ville` + `Code Postal` + `Adresse` (champ contact natif) | `EMvUAfCd1nfK92XOFwWg` (ville), `p6fMlu1tddxVmL4i0FSN` (CP), natif | Déjà câblé Phase 1 (parsing depuis adresse Google Places). Confirmé via `app/api/leads/route.ts:132-149` + 174-177. |
+| **Wizard Q1** | Symptômes (multi-select, 1-7 cochés) | `v2Answers.symptoms` (string[]) | `Symptoms` (TEXT, CSV) | `ZPE3HqwuNU2UFMPJoFLP` | **Phase 2** ajout dans `app/api/leads/route.ts` bloc isolation : `symptoms: leadData.userAnswers.symptoms.join(',')` → ex `"hydro_up,cold_winter,drafts"`. |
+| **Wizard Q2** | Bracket facture Hydro (1 sélection) | `v2Answers.hydroBracket` | `Hydro Bracket` (TEXT) | `09Yv7GFbSI63gpw2dnMS` | **Phase 2** ajout : `hydro_bracket: leadData.userAnswers.hydroBracket` → ex `"125_200"`. |
+| **Wizard Q3** | Intent (qualifié/curieux) | `v2Answers.intent` | `Intent` (TEXT) | `TXLCBATiEunuBmhBfiPk` | **Phase 2** ajout : `intent: leadData.userAnswers.intent` → `"qualified"` ou `"curious"`. |
+| **Lead form** | Prénom | `firstName` | `firstName` (champ contact natif GHL) | natif | Déjà câblé Phase 1 (`ghlPayload.firstName`). |
+| **Lead form** | Nom | `lastName` | `lastName` (natif) | natif | Déjà câblé Phase 1. |
+| **Lead form** | Courriel | `email` | `email` (natif) | natif | Déjà câblé Phase 1. |
+| **Lead form** | Téléphone | `phone` | `phone` (natif, format E.164) | natif | Déjà câblé Phase 1 (normalisé par `normalizePhone`). |
+| **Système** | Pricing 3-tier généré | `pricingData.ranges.{economique,standard,premium}.totalCost.{min,max}` | `Econo - Prix min/max`, `Standard - Prix min/max`, `Premium - Prix min/max` (6 fields NUMERICAL) | `cWppmyPcMVWcVLwKxMCR`, `Soof0hnOH7S8i6NUE0ce`, `QpUhBlUPZzXONoEKdMIQ`, `YcnckovWf0PTjDrMQQcN`, `sAAdL21LGBrzhkM9F0XQ`, `2UI5mQyBd0XiVTgeUCOM` | Déjà câblé Phase 1. |
+| **Système** | Données roof-analysis | `roofData.{roofArea, buildingHeight, pitchComplexity, obstacles, segments, usableArea, accessDifficulty, roofShape}` | `Superficie total`, `Hauteur du batiment`, `Complexite pente`, `Obstacles`, `Nb segments toiture`, `Surface utilisable`, `Difficulte acces`, `Forme du toit` (8 fields) | `jF5Z4GbAd3sU07GDn5sh`, `Pgf8Y8PuZJrHyPC2i2kI`, `9sNa4ZxBmzClRrnqutJD`, `iBXckfYmOfTmBg3DiZL8`, `9BewnDwPRCR4YB9AMdIQ`, `Nruym6OYXwH0N5lC26GG`, `SZ47se1OmmZods3muSJR`, `E2QSWv69HkQJuas2o4bM` | Déjà câblé Phase 1. |
+| **Système** | UTM + attribution | `utmParams.{utm_source, utm_campaign, utm_content, utm_medium, fbclid}` + `landingPage` | `UTM Source`, `Campaign Name`, `Ad Name`, `fbclid`, `Landing Page`, `Lead Source` (6 fields) | `PGJTGfRsDp4ZnBmINzVO`, `uzf5PgMaRV67z7IpI9kT`, `PIWz9wyYpNE8YzgN8IrP`, `c3HEuK4wMPoMxQP36Uzl`, `WmUBBdtaVnnrUA1A0jh3`, `ckqcPkIu73xuG1OMkZzh` | Déjà câblé Phase 1. |
+| **Système** | Coordonnées GPS | `roofData.coordinates.{lat, lng, province}` | `Latitude`, `Longitude`, `Province` (3 fields TEXT) | `ZMWiwWMjby6YaJwncCj5`, `ws8VSXNw4b51F5dSuhx4`, `7o3FvYluyCMQKB1zjFgV` | Déjà câblé Phase 1. |
+| **Système (V1 backward compat)** | Heating system (default 'electricite'), Current insulation (default 'partielle'), Attic access (default 'facile'), Problèmes V1 (mapped from V2 symptoms) | `userAnswers.heatingSystem/currentInsulation/atticAccess/identifiedProblems` | `Systeme de chauffage`, `Isolation actuelle`, `Acces entretoit`, `Problemes identifies` (4 fields TEXT) | `MKyNDO2uDbGxYSbYp7qw`, `9di5URhx4SplO59qhUCh`, `xtFWNuPCvibxk3oc7eDR`, `LWQ1sDv3KlJJxO3XpmDU` | Déjà câblé Phase 1. Conservés Phase 2 pour ne pas casser workflows GHL existants. |
+| **Tag GHL** | Statut qualification | dérivé de `userAnswers.intent` | tag contact (pas un custom field) | n/a | **Phase 2** : `Lead Iso Hot` si qualifié OU `Lead Iso Curieux` si curieux, via `tagOverride` dans NormalizedLead. Override curieux→qualifié retire `Lead Iso Curieux`. |
+| **Lead ID** | Identifiant unique lead | `leadId` (généré client `LEAD<ts><random>`) | source du contact GHL | n/a | Déjà câblé Phase 1 (`internalLeadId: leadId`). Stocké aussi dans payload pour traçabilité. |
+
+### Vérification visuelle pendant les tests
+
+Pendant le **Test 1** (lead qualifié OTP enabled, cf section "Tests Phase 2"), ouvrir le contact dans l'UI GHL sub-account Iso et vérifier que **chaque ligne du tableau ci-dessus est présente**. Si un field est vide ou absent → flag immédiatement avant merge.
+
+Champ critique de Phase 2 à valider en priorité : `Symptoms`, `Hydro Bracket`, `Intent` (les 3 nouveaux V2). Les autres sont déjà testés Phase 1.
+
+---
+
+## Phase 2.5 — Retirer `CompleteRegistration`
+
+### Fichier modifié : [app/soumission-rapide/merci/page.tsx](soumissionconfort/app/soumission-rapide/merci/page.tsx)
+
+Lignes ~70-78 : supprimer le bloc :
+```ts
+window.fbq("track", "CompleteRegistration", {
+  content_name: "soumission-rapide-isolation",
+  currency: "CAD",
+})
+```
+
+Funnel inactif → impact prod nul. Vérifier qu'il n'y a pas d'appel CAPI `CompleteRegistration` ailleurs (`grep -ri CompleteRegistration soumissionconfort/`).
+
+---
+
+## Phase 2.6 — Documentation env vars
+
+### Fichier modifié : [ENV_VARIABLES.md](soumissionconfort/ENV_VARIABLES.md)
+
+Ajouter une section sous `# META / FACEBOOK` :
+
+```markdown
+# Pixel dédié soumissionconfort (funnel /analysis V2)
+NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT=<pixel ID>
+META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT=<token CAPI>
+META_TEST_EVENT_CODE_SOUMISSIONCONFORT=  # optionnel — tests events Manager
+```
+
+Avec commentaire : « Utilisé uniquement par le funnel /analysis. Les autres funnels (/thermopompes, /subventions, /soumission-rapide) continuent sur NEXT_PUBLIC_META_PIXEL_ID. »
+
+---
+
+## Tests Phase 2
+
+### Test 1 — Lead qualifié, OTP enabled (path prod principal)
+
+1. `cd soumissionconfort && npm run dev -- -p 3001`
+2. Homepage → entrer adresse → click "Obtenir mon estimation gratuite" → **Network tab** : `POST /api/meta/view-content` 200 ; **Meta Events Manager** (sur le pixel dédié, en test mode) : ViewContent reçu eventId X (browser fbq + CAPI dedupé).
+3. Loading → wizard Q1 → Q2 → Q3 intent **qualifié** → lead form → submit → redirect `/verifier-telephone`.
+4. Recevoir SMS → entrer code → POST `/api/leads` 200 → **Meta Events Manager** : `Lead` browser + CAPI tous deux reçus, eventId Y identique, service_type=isolation. Dedup OK.
+5. **GHL UI sub-account Iso** : nouveau contact avec tag `Lead Iso Hot`, custom fields `Symptoms`, `Hydro Bracket`, `Intent=qualified` remplis + V1 defaults toujours présents.
+
+### Test 2 — Lead curieux, OTP enabled
+
+1-3. Idem mais intent **curieux**.
+4. Confirmer OTP → POST `/api/leads` 200. **Meta Events Manager** : `Lead` **PAS reçu** (ni browser ni CAPI). ViewContent toujours là.
+5. **GHL** : contact avec tag `Lead Iso Curieux`, `Intent=curious`.
+
+### Test 3 — Override tag : curieux → qualifié
+
+1. Faire 1 lead curieux avec email X → tag `Lead Iso Curieux` posé.
+2. Refaire 1 lead qualifié avec **le même email X** (upsert → même contact).
+3. **GHL UI** : le contact a maintenant **uniquement `Lead Iso Hot`** (`Lead Iso Curieux` retiré via DELETE).
+4. Vérifier dans Vercel logs : `[ghl-client] tag removal failed` **ne doit pas** apparaître.
+
+### Test 4 — Non-régression `/thermopompes`, `/subventions`
+
+1. Lead `/thermopompes` complet → vérifier que Meta Lead CAPI est toujours envoyé **sur l'ancien pixel** (`NEXT_PUBLIC_META_PIXEL_ID`, pas le nouveau). Tag GHL `Lead HVAC` inchangé.
+2. Pareil `/subventions`. Aucun appel vers le pixel soumissionconfort.
+
+### Test 5 — Garde-fou placeholder
+
+1. `.env.local` : `NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT=XXXXXX`.
+2. Restart dev → lead qualifié → console : `[view-content] skip` + `[leads] skip Meta CAPI Lead — soumissionconfort pixel/token is placeholder`. Pas de call vers `graph.facebook.com`. Pas de crash.
+
+### Test 6 — TypeScript + build
+
+- `cd soumissionconfort && npx tsc --noEmit` clean.
+- Kill dev avant : `npm run build` succès (cf gotcha CLAUDE.md global — ne pas build avec dev actif).
+
+### Test 7 — CompleteRegistration grep clean
+
+- `grep -ri "CompleteRegistration" soumissionconfort/` → résultat vide.
+
+---
+
+## Fichiers touchés (récap)
+
+| Fichier | Type | Changement clé |
+|---|---|---|
+| [lib/meta-config.ts](soumissionconfort/lib/meta-config.ts) | modif | Ajout `META_CONFIG_SOUMISSIONCONFORT` + `isSoumissionConfortMetaConfigured()` |
+| [components/meta-pixel-router.tsx](soumissionconfort/components/meta-pixel-router.tsx) | **nouveau** | Composant client qui détecte `usePathname()` et charge soit le pixel actuel soit le pixel dédié selon la route. Charge UN SEUL pixel à la fois. |
+| [app/layout.tsx](soumissionconfort/app/layout.tsx) | modif | Retirer le `<Script>` Meta Pixel inline (lignes 166-195). Remplacer par `<MetaPixelRouter />`. |
+| [app/verifier-telephone/page.tsx](soumissionconfort/app/verifier-telephone/page.tsx) | modif | Fire Lead post-OTP gated intent qualifié + même eventId que CAPI (cf Phase 2.3) |
+| [lib/meta-conversion-api.ts](soumissionconfort/lib/meta-conversion-api.ts) | modif | Refactor `trackViewContent` pour accepter `eventId` + `clientIp/userAgent/sourceUrl` |
+| [app/page.tsx](soumissionconfort/app/page.tsx) | modif | Dans `navigateToAnalysis()` : fire browser fbq ViewContent + POST `/api/meta/view-content` avec eventId partagé. Adapter aussi l'appel `trackViewContent('Homepage'…)` à la nouvelle signature. |
+| [app/api/meta/view-content/route.ts](soumissionconfort/app/api/meta/view-content/route.ts) | **nouveau** | Endpoint CAPI ViewContent → pixel dédié soumissionconfort |
+| [components/lead-capture-form.tsx](soumissionconfort/components/lead-capture-form.tsx) | modif | Retirer fbq Lead client (lignes 124-137). Stash `pending.meta = { intent, estimatedValue }`. Path non-OTP : Lead fire APRÈS `/api/leads` succès, gated `qualified`. |
+| [app/verifier-telephone/page.tsx](soumissionconfort/app/verifier-telephone/page.tsx) | modif | Après `submitDeferredLead` OK : fire `fbq('Lead', ...)` gated intent qualifié, même eventId que CAPI |
+| [app/api/leads/route.ts](soumissionconfort/app/api/leads/route.ts) | modif | (1) Pixel ID/token = soumissionconfort pour vertical='isolation'. (2) Gate `trackLead` par `intent === 'qualified'` (isolation seul). (3) Ajout `symptoms`, `hydro_bracket`, `intent` au `custom` GHL. (4) `tagOverride` = `Lead Iso Hot`/`Lead Iso Curieux` + `tagsToRemove` pour override curieux→qualifié. |
+| [lib/ghl-client.ts](soumissionconfort/lib/ghl-client.ts) | modif | Ajout `tagOverride?` + `tagsToRemove?` à `NormalizedLead`. Use dans `buildContactPayload`. Best-effort DELETE `/contacts/{id}/tags` après upsert si `tagsToRemove`. |
+| [app/soumission-rapide/merci/page.tsx](soumissionconfort/app/soumission-rapide/merci/page.tsx) | modif | Retirer `fbq("track", "CompleteRegistration", ...)` |
+| [ENV_VARIABLES.md](soumissionconfort/ENV_VARIABLES.md) | modif | Documenter les 3 nouvelles env vars soumissionconfort |
+
+---
+
+## Hors scope Phase 2 (consigné pour suite)
+
+- **Migration autres funnels (`/thermopompes`, `/subventions`, `/soumission-rapide`) vers pixel soumissionconfort** : non touché.
+- **Copy CTA différenciée selon intent sur `InsulationResults`** : Zack a tranché « même copy ».
+- **Make webhook columns V2** : branche legacy bypassée en prod, non câblée.
+- **Suppression V1 defaults dans payload `/api/leads`** : conservés pour backward compat GHL workflows.
+- **Pricing 3-tier dégradation V2** : déjà acceptée Phase 1, pas re-touché.
+- **Second `<Script>` Pixel browser dédié sur `/analysis*`** : à confirmer avec Zack (cf question ouverte). Si Zack veut « Lead browser ET CAPI tous les deux sur le pixel dédié soumissionconfort » → ajouter un composant `<MetaPixelSoumissionConfort />` monté sur les pages `/analysis*` et `/verifier-telephone`. Si non → ViewContent + Lead browser restent sur le pixel global, seul CAPI part sur le pixel dédié (sub-optimal pour dedup).
+
+---
+
+## Vérifications avant PR Phase 2
+
+- [ ] Tests 1-7 ci-dessus tous OK en local + Vercel preview
+- [ ] `npx tsc --noEmit` clean
+- [ ] `npm run build` succès
+- [ ] PR Phase 2 ouverte vs **`feat/analysis-funnel-v2`** (PAS `main`), body explique le lien avec PR #20
+- [ ] Code review Claude + Codex via `/commit-push-pr`
+- [ ] **Merge final** : Zack créé manuellement le workflow GHL `Lead Iso Hot` → stage "New Lead Hot". PR Phase 1 + Phase 2 mergées dans `main` ensemble.
+
+---
+
+## Décisions verrouillées avec Zack (finales)
+
+1. **Pixel actuel (Niku)** : désactivé sur `/analysis*` + `/verifier-telephone`. Sert toujours homepage + thermopompes + subventions + soumission-rapide comme aujourd'hui.
+2. **Pixel dédié soumissionconfort** : chargé uniquement sur `/analysis*` + `/verifier-telephone` via `<MetaPixelRouter />` (composant client qui détecte `usePathname()`). PageView + ViewContent (wizard mount) + Lead (post-OTP qualifié) tous envoyés à ce pixel uniquement.
+3. **Pixel ownership Meta** : le pixel dédié est créé dans le **Business Manager Meta de soumissionconfort** (séparé du Business Manager qui héberge le pixel actuel). Audiences cloisonnées par construction.
+4. **Test Event Code** : `META_TEST_EVENT_CODE_SOUMISSIONCONFORT` configuré en `.env.local` + Vercel preview. Permet de tester en Events Manager → Test Events sans polluer le live. Le code est ignoré automatiquement en prod (garde-fou existant dans `lib/meta-conversion-api.ts:293-297`).
+5. **Garde-fou placeholder XXXXXX** : **strict, pas de fallback**. Si `NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT` = placeholder → `MetaPixelRouter` retourne `null` sur `/analysis*` + `/verifier-telephone` → aucun pixel browser chargé sur le funnel. CAPI server skip aussi (`isSoumissionConfortMetaConfigured()` = false). Pas de pollution du pixel actuel pendant la transition.
+6. **Homepage** : reste sur le pixel actuel (statu quo). Le pixel dédié ne charge qu'à partir de `/analysis`. Audience pixel dédié = users qui ont vraiment cliqué pour commencer l'estimation iso (pas les bounces homepage).
+7. **`isTest` gate** : si `leadData.isTest === true` arrive dans `/api/leads`, le Meta CAPI Lead skip silencieusement (`console.log('[leads] skip Meta CAPI Lead — isTest=true')`). Permet replay/debug Make ou Postman sans polluer Meta. Documenter dans le PR.
+8. **Override tag GHL** : sens unique. Curieux → qualifié retire `Lead Iso Curieux`. Qualifié → curieux **ne retire pas** `Lead Iso Hot` (une fois qualifié, toujours qualifié).
+
+## P0 fixes intégrés (adversarial review)
+
+- **P0-1** : `keepalive: true` sur le fetch ViewContent CAPI (sinon event perdu au `router.push`).
+- **P0-2** : route group `(analysis-funnel)/layout.tsx` pour monter le pixel dédié **une seule fois** (sinon double init + double PageView).
+- **P0-3** : `leadPayload.eventId` reste top-level pour que `/verifier-telephone` puisse le réutiliser et déduper browser Lead ↔ CAPI Lead.
+
+## Question à valider en preview (mini-fix éventuel)
+
+- **Body schema `DELETE /contacts/{id}/tags`** : inféré `{ tags: [string] }` par cohérence avec ADD. Doc officielle ne le confirme pas explicitement. À tester en preview avec un curl manuel sur un contact test avant prod. Si schema diffère (ex : `?tag=X` query param), mini-fix à appliquer dans `lib/ghl-client.ts`.
+
+Sources :
+- [HighLevel API Remove Tags](https://marketplace.gohighlevel.com/docs/ghl/contacts/remove-tags)
+- [HighLevel API Add Tags](https://marketplace.gohighlevel.com/docs/ghl/contacts/add-tags/index.html)

--- a/app/analysis/page.tsx
+++ b/app/analysis/page.tsx
@@ -8,7 +8,7 @@ import { LeadCaptureForm, type LeadData } from "@/components/lead-capture-form"
 import { useLanguage } from "@/lib/language-context"
 import { ArrowLeft, MapPin, Zap, Clock, CheckCircle, Pencil, Check } from 'lucide-react'
 import Link from "next/link"
-import type { V2Answers } from "@/lib/funnel-config"
+import { buildV1AnswersFromV2, type V2Answers } from "@/lib/funnel-config"
 
 type AnalysisStep = "loading" | "results" | "questionnaire" | "lead-capture" | "pricing"
 
@@ -295,7 +295,7 @@ export default function AnalysisPage() {
         {currentStep === "pricing" && roofData && userAnswers && leadData && (
           <InsulationResults
             roofData={roofData}
-            userAnswers={userAnswers}
+            userAnswers={buildV1AnswersFromV2(userAnswers)}
             leadData={leadData}
             onComplete={() => router.push("/success")}
           />

--- a/app/analysis/page.tsx
+++ b/app/analysis/page.tsx
@@ -4,16 +4,11 @@ import { useSearchParams, useRouter } from "next/navigation"
 import { useState, useEffect, useMemo } from "react"
 import { UserQuestionnaire } from "@/components/user-questionnaire-wizard"
 import { InsulationResults } from "@/components/insulation-results"
-import { LeadCaptureForm } from "@/components/lead-capture-form"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Progress } from "@/components/ui/progress"
-import { Badge } from "@/components/ui/badge"
+import { LeadCaptureForm, type LeadData } from "@/components/lead-capture-form"
 import { useLanguage } from "@/lib/language-context"
-import { OTP_ENABLED } from "@/lib/feature-flags"
 import { ArrowLeft, MapPin, Zap, Clock, CheckCircle, Pencil, Check } from 'lucide-react'
 import Link from "next/link"
-import type { LeadData } from "@/components/lead-capture-popup"
-import { Analytics } from "@vercel/analytics/next"
+import type { V2Answers } from "@/lib/funnel-config"
 
 type AnalysisStep = "loading" | "results" | "questionnaire" | "lead-capture" | "pricing"
 
@@ -25,9 +20,9 @@ export default function AnalysisPage() {
   // State declarations need to come before effects to avoid TDZ errors
   const [currentStep, setCurrentStep] = useState<AnalysisStep>("loading")
   const [roofData, setRoofData] = useState<any>(null)
-  const [userAnswers, setUserAnswers] = useState<any>(null)
+  const [userAnswers, setUserAnswers] = useState<V2Answers | null>(null)
   const [leadData, setLeadData] = useState<LeadData | null>(null)
-  const [pricingData, setPricingData] = useState<any>(null)
+  const [, setPricingData] = useState<any>(null)
   const [hasAnalyzed, setHasAnalyzed] = useState(false)
   const [isEditingArea, setIsEditingArea] = useState(false)
   const [areaInputValue, setAreaInputValue] = useState("")
@@ -50,8 +45,14 @@ export default function AnalysisPage() {
   const dataParam = useMemo(() => searchParams.get("data"), [searchParams])
 
   useEffect(() => {
-    // Ensure we're on the client side and have an address
-    if (typeof window === 'undefined' || hasAnalyzed || !address) return
+    // SSR guard
+    if (typeof window === 'undefined') return
+    // No address in URL → redirect home (P1-6 — prevents infinite spinner).
+    if (!address) {
+      router.push('/')
+      return
+    }
+    if (hasAnalyzed) return
 
     const analyzeRoof = async () => {
       setHasAnalyzed(true)
@@ -125,7 +126,7 @@ export default function AnalysisPage() {
     }, 100)
 
     return () => clearTimeout(timeoutId)
-  }, [address, dataParam, hasAnalyzed])
+  }, [address, dataParam, hasAnalyzed, router])
 
   const getStepProgress = () => {
     switch (currentStep) {
@@ -159,47 +160,16 @@ export default function AnalysisPage() {
     }
   }
 
-  const handleQuestionnaireComplete = async (answers: any, capturedLeadData: LeadData, pricingData: any) => {
+  // V2 flow: wizard hands off answers only; pricing + API + OTP happen in
+  // LeadCaptureForm. State machine: questionnaire → lead-capture → pricing.
+  const handleQuestionnaireComplete = (answers: V2Answers) => {
     setUserAnswers(answers)
-    setLeadData(capturedLeadData)
-    setPricingData(pricingData)
-
-    // Store pricing data in sessionStorage and redirect to /pricing page
-    const leadId = capturedLeadData.leadId
-    if (leadId) {
-      try {
-        const ctx = { roofData, userAnswers: answers, leadData: capturedLeadData }
-        sessionStorage.setItem('pricingContext', JSON.stringify(ctx))
-        // Also encode minimal non-PII data in URL for resilience (refresh, new tab)
-        const urlData = btoa(JSON.stringify({
-          roofArea: roofData?.roofArea,
-          pitch: roofData?.pitch,
-          heatingSystem: answers?.heatingSystem,
-          currentInsulation: answers?.currentInsulation,
-          atticAccess: answers?.atticAccess,
-          identifiedProblems: answers?.identifiedProblems,
-        }))
-        const pricingUrl = `/pricing?leadId=${leadId}&d=${urlData}`
-        if (OTP_ENABLED) {
-          // Update redirectTo to point to pricing page (phone already set by wizard)
-          const otpData = JSON.parse(sessionStorage.getItem('otp-verify') || '{}')
-          sessionStorage.setItem('otp-verify', JSON.stringify({ ...otpData, redirectTo: pricingUrl }))
-          router.push('/verifier-telephone')
-        } else {
-          router.push(pricingUrl)
-        }
-      } catch (error) {
-        console.error('Error storing pricing data:', error)
-        setCurrentStep("pricing")
-      }
-    } else {
-      // Fallback if no leadId
-      setCurrentStep("pricing")
-    }
+    setCurrentStep("lead-capture")
   }
 
-  const handleLeadCaptureComplete = (pricing: any) => {
+  const handleLeadCaptureComplete = (pricing: any, captured: LeadData, _leadId: string) => {
     setPricingData(pricing)
+    setLeadData(captured)
     setCurrentStep("pricing")
   }
 
@@ -314,8 +284,12 @@ export default function AnalysisPage() {
           <UserQuestionnaire roofData={roofData} onComplete={handleQuestionnaireComplete} />
         )}
 
-        {currentStep === "lead-capture" && roofData && userAnswers && leadData && (
-          <LeadCaptureForm roofData={roofData} userAnswers={userAnswers} leadData={leadData} onComplete={handleLeadCaptureComplete} />
+        {currentStep === "lead-capture" && roofData && userAnswers && (
+          <LeadCaptureForm
+            roofData={roofData}
+            v2Answers={userAnswers}
+            onComplete={handleLeadCaptureComplete}
+          />
         )}
 
         {currentStep === "pricing" && roofData && userAnswers && leadData && (
@@ -323,14 +297,7 @@ export default function AnalysisPage() {
             roofData={roofData}
             userAnswers={userAnswers}
             leadData={leadData}
-            onComplete={() => {
-              // Redirect to OTP verification before success page
-              if (OTP_ENABLED) {
-                router.push("/verifier-telephone")
-              } else {
-                router.push("/success")
-              }
-            }}
+            onComplete={() => router.push("/success")}
           />
         )}
       </main>

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -206,6 +206,14 @@ export async function POST(request: NextRequest) {
               isolation_actuelle: leadData.userAnswers?.currentInsulation,
               acces_entretoit: leadData.userAnswers?.atticAccess,
               systeme_de_chauffage: leadData.userAnswers?.heatingSystem,
+              // V2 funnel fields — wired Phase 2 (IDs in GHL_FIELDS_ISO 41-43).
+              // V1 defaults above are kept for backward-compat with existing
+              // GHL workflows; these add the real V2 answers alongside.
+              symptoms: Array.isArray(leadData.userAnswers?.symptoms)
+                ? leadData.userAnswers.symptoms.join(',')
+                : leadData.userAnswers?.symptoms,
+              hydro_bracket: leadData.userAnswers?.hydroBracket,
+              intent: leadData.userAnswers?.intent,
               problemes_identifies: Array.isArray(leadData.userAnswers?.identifiedProblems)
                 ? leadData.userAnswers.identifiedProblems.join(', ')
                 : leadData.userAnswers?.identifiedProblems,
@@ -246,6 +254,19 @@ export async function POST(request: NextRequest) {
           },
         }
 
+        // Phase 2 V2: dynamic qualification tag for the /analysis funnel.
+        //  - qualified → 'Lead Iso Hot' + drop 'Lead Iso Curieux' (override).
+        //  - curious   → 'Lead Iso Curieux' (no removal: once hot, stays hot —
+        //    qualified→curious does NOT strip 'Lead Iso Hot', Zack v2 décision 8).
+        if (vertical === 'isolation' && leadData.userAnswers?.intent) {
+          if (leadData.userAnswers.intent === 'qualified') {
+            ghlPayload.tagOverride = 'Lead Iso Hot'
+            ghlPayload.tagsToRemove = ['Lead Iso Curieux']
+          } else if (leadData.userAnswers.intent === 'curious') {
+            ghlPayload.tagOverride = 'Lead Iso Curieux'
+          }
+        }
+
         const ghlResult = await postLeadToGHL(ghlPayload)
         console.log('🟢 LEADS API: GHL post result:', ghlResult)
 
@@ -266,11 +287,37 @@ export async function POST(request: NextRequest) {
         // the GHL cutover. The legacy block at the bottom of this file is
         // skipped by the early return below; without this duplicate, GHL
         // contacts wouldn't get a Meta Lead event.
+        //
+        // Phase 2 V2: for vertical='isolation' (the /analysis funnel) the Lead
+        // routes to the DEDICATED soumissionconfort pixel and is gated by
+        // intent === 'qualified'. Every other vertical stays on the shared
+        // pixel, ungated, exactly as before.
         try {
-          const metaPixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID
-          const metaAccessToken = process.env.META_CONVERSION_ACCESS_TOKEN
-          if (metaPixelId && metaAccessToken) {
-            const metaAPI = initializeMetaConversionAPI(metaPixelId, metaAccessToken)
+          const useSoumissionConfortPixel = vertical === 'isolation'
+          const metaPixelId = useSoumissionConfortPixel
+            ? process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT
+            : process.env.NEXT_PUBLIC_META_PIXEL_ID
+          const metaAccessToken = useSoumissionConfortPixel
+            ? process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT
+            : process.env.META_CONVERSION_ACCESS_TOKEN
+          const metaTestEventCode = useSoumissionConfortPixel
+            ? process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT
+            : process.env.META_TEST_EVENT_CODE
+
+          const isPlaceholder = (v?: string) => !!v && /^X+$/i.test(v)
+          // Only the isolation funnel is intent-gated; other verticals always fire.
+          const intentGateOk = !useSoumissionConfortPixel
+            || leadData.userAnswers?.intent === 'qualified'
+          // isTest gate (Zack v2 décision 7): replay/debug payloads never reach Meta.
+          const isTestLead = leadData.isTest === true
+
+          if (
+            !isTestLead
+            && metaPixelId && metaAccessToken
+            && !isPlaceholder(metaPixelId) && !isPlaceholder(metaAccessToken)
+            && intentGateOk
+          ) {
+            const metaAPI = initializeMetaConversionAPI(metaPixelId, metaAccessToken, metaTestEventCode)
             const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0] ||
                              request.headers.get('x-real-ip') || 'unknown'
             const userAgent = request.headers.get('user-agent') || 'unknown'
@@ -311,7 +358,13 @@ export async function POST(request: NextRequest) {
               eventId: leadData.eventId || undefined,
               customData: { service_type: serviceType },
             })
-            console.log(`✅ LEADS API: Meta CAPI event sent (GHL branch, ${serviceType})`)
+            console.log(`✅ LEADS API: Meta CAPI Lead sent (GHL branch, ${serviceType}, pixel=${useSoumissionConfortPixel ? 'soumissionconfort' : 'shared'})`)
+          } else if (isTestLead) {
+            console.log('[leads] skip Meta CAPI Lead — isTest=true')
+          } else if (useSoumissionConfortPixel && !intentGateOk) {
+            console.log('[leads] skip Meta CAPI Lead — intent !== qualified')
+          } else if (useSoumissionConfortPixel && (isPlaceholder(metaPixelId) || isPlaceholder(metaAccessToken))) {
+            console.warn('[leads] skip Meta CAPI Lead — soumissionconfort pixel/token is placeholder XXXXXX')
           } else {
             console.warn('⚠️ LEADS API: Meta CAPI not configured (GHL branch)')
           }
@@ -744,21 +797,43 @@ export async function POST(request: NextRequest) {
         console.error('❌ LEADS API: All webhooks failed')
       }
       
-      // Server-side Meta Conversion API tracking for ALL lead types
+      // Server-side Meta Conversion API tracking for ALL lead types.
+      // NOTE: this legacy Make path is NOT executed in prod (GHL_ENABLED=true),
+      // but we mirror the GHL-branch gating for consistency: isolation routes to
+      // the dedicated pixel + intent gate, others stay on the shared pixel,
+      // and isTest leads never reach Meta.
       if (successfulWebhooks > 0) {
         try {
-          const metaPixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID
-          const metaAccessToken = process.env.META_CONVERSION_ACCESS_TOKEN
-          
-          if (metaPixelId && metaAccessToken) {
-            const metaAPI = initializeMetaConversionAPI(metaPixelId, metaAccessToken)
-            
+          const useSoumissionConfortPixel = leadType === 'isolation'
+          const metaPixelId = useSoumissionConfortPixel
+            ? process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT
+            : process.env.NEXT_PUBLIC_META_PIXEL_ID
+          const metaAccessToken = useSoumissionConfortPixel
+            ? process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT
+            : process.env.META_CONVERSION_ACCESS_TOKEN
+          const metaTestEventCode = useSoumissionConfortPixel
+            ? process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT
+            : process.env.META_TEST_EVENT_CODE
+
+          const isPlaceholder = (v?: string) => !!v && /^X+$/i.test(v)
+          const intentGateOk = !useSoumissionConfortPixel
+            || leadData.userAnswers?.intent === 'qualified'
+          const isTestLead = leadData.isTest === true
+
+          if (
+            !isTestLead
+            && metaPixelId && metaAccessToken
+            && !isPlaceholder(metaPixelId) && !isPlaceholder(metaAccessToken)
+            && intentGateOk
+          ) {
+            const metaAPI = initializeMetaConversionAPI(metaPixelId, metaAccessToken, metaTestEventCode)
+
             // Get client IP and user agent from request headers
-            const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0] || 
-                            request.headers.get('x-real-ip') || 
+            const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0] ||
+                            request.headers.get('x-real-ip') ||
                             'unknown'
             const userAgent = request.headers.get('user-agent') || 'unknown'
-            
+
             // Determine service_type and value based on lead type
             const serviceTypeMap: Record<string, string> = {
               'isolation': 'isolation',
@@ -767,11 +842,11 @@ export async function POST(request: NextRequest) {
               'hvac': 'thermopompe',
             }
             const serviceType = serviceTypeMap[leadType] || 'isolation'
-            
+
             // Calculate estimated value for tracking
             let estimatedValue = 0
             if (isHVAC) {
-              estimatedValue = leadData.estimatedPrice || 
+              estimatedValue = leadData.estimatedPrice ||
                               ((leadData.estimatedPriceMin || 0) + (leadData.estimatedPriceMax || 0)) / 2
             } else if (isSubvention) {
               estimatedValue = 1500 // Subvention value
@@ -781,7 +856,7 @@ export async function POST(request: NextRequest) {
               const stdMax = leadData.pricingData?.ranges?.standard?.totalCost?.max || 0
               estimatedValue = (stdMin + stdMax) / 2
             }
-            
+
             // Determine source URL based on lead type
             const sourceUrlMap: Record<string, string> = {
               'isolation': '/analysis',
@@ -790,9 +865,9 @@ export async function POST(request: NextRequest) {
             }
             const sourcePath = sourceUrlMap[leadType] || '/'
             const origin = request.headers.get('origin') || 'https://soumissionconfort.ai'
-            
-            console.log(`📊 LEADS API: Sending server-side Meta Lead event for ${serviceType} (eventId: ${leadData.eventId || 'none'})`)
-            
+
+            console.log(`📊 LEADS API: Sending server-side Meta Lead event for ${serviceType} (eventId: ${leadData.eventId || 'none'}, pixel=${useSoumissionConfortPixel ? 'soumissionconfort' : 'shared'})`)
+
             await metaAPI.trackLead({
               email: leadData.email,
               phone: leadData.phone,
@@ -807,8 +882,14 @@ export async function POST(request: NextRequest) {
                 service_type: serviceType
               }
             })
-            
+
             console.log(`✅ LEADS API: Server-side Meta Lead event sent successfully for ${serviceType}`)
+          } else if (isTestLead) {
+            console.log('[leads] skip Meta CAPI Lead — isTest=true (legacy path)')
+          } else if (useSoumissionConfortPixel && !intentGateOk) {
+            console.log('[leads] skip Meta CAPI Lead — intent !== qualified (legacy path)')
+          } else if (useSoumissionConfortPixel && (isPlaceholder(metaPixelId) || isPlaceholder(metaAccessToken))) {
+            console.warn('[leads] skip Meta CAPI Lead — soumissionconfort pixel/token is placeholder XXXXXX (legacy path)')
           } else {
             console.warn('⚠️ LEADS API: Meta Pixel credentials not configured for server-side tracking')
           }

--- a/app/api/meta/view-content/route.ts
+++ b/app/api/meta/view-content/route.ts
@@ -1,0 +1,48 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { MetaConversionAPI } from '@/lib/meta-conversion-api'
+import {
+  META_CONFIG_SOUMISSIONCONFORT,
+  isSoumissionConfortMetaConfigured,
+} from '@/lib/meta-config'
+
+// CAPI ViewContent for the /analysis wizard → dedicated soumissionconfort
+// pixel only. Browser fbq fires the matching ViewContent with the same eventId
+// (see user-questionnaire-wizard.tsx) so Meta dedups to a single event.
+//
+// Skips silently when the dedicated pixel isn't configured yet (placeholder
+// rollout window) — never falls back to the shared pixel.
+export async function POST(request: NextRequest) {
+  if (!isSoumissionConfortMetaConfigured()) {
+    console.warn('[view-content] Meta CAPI not configured for soumissionconfort (skip)')
+    return NextResponse.json({ skipped: true })
+  }
+
+  try {
+    const { eventId, sourceUrl, address } = await request.json()
+    const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0]
+      || request.headers.get('x-real-ip')
+      || 'unknown'
+    const userAgent = request.headers.get('user-agent') || 'unknown'
+
+    const metaAPI = new MetaConversionAPI(
+      META_CONFIG_SOUMISSIONCONFORT.PIXEL_ID,
+      META_CONFIG_SOUMISSIONCONFORT.ACCESS_TOKEN,
+      META_CONFIG_SOUMISSIONCONFORT.TEST_EVENT_CODE,
+    )
+
+    await metaAPI.trackViewContent({
+      eventId,
+      sourceUrl,
+      clientIp,
+      userAgent,
+      contentName: 'analysis-wizard-v2',
+      contentType: 'isolation',
+      searchString: address,
+    })
+
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('[view-content] CAPI error', err)
+    return NextResponse.json({ ok: false }, { status: 500 })
+  }
+}

--- a/app/api/test-meta/route.ts
+++ b/app/api/test-meta/route.ts
@@ -41,7 +41,7 @@ export async function POST(request: NextRequest) {
 
     // Test ViewContent event
     console.log('🧪 Testing ViewContent event...')
-    const viewContentResult = await trackViewContent('Test Page', 'test')
+    const viewContentResult = await trackViewContent({ contentName: 'Test Page', contentType: 'test' })
     console.log('📊 ViewContent Result:', viewContentResult)
 
     // Test Lead event with sample data

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Radio_Canada_Big, Source_Serif_4 } from 'next/font/google'
 import "./globals.css"
 import { LanguageProvider } from "@/lib/language-context"
 import { Analytics } from "@vercel/analytics/next"
+import { MetaPixelRouter } from "@/components/meta-pixel-router"
 
 const radioCanadaBig = Radio_Canada_Big({
   subsets: ["latin"],
@@ -163,38 +164,12 @@ export default function RootLayout({
           }}
         />
 
-        {process.env.NEXT_PUBLIC_META_PIXEL_ID && (
-          <>
-            {/* Meta Pixel Code */}
-            <script
-              dangerouslySetInnerHTML={{
-                __html: `
-                  !function(f,b,e,v,n,t,s)
-                  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-                  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-                  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-                  n.queue=[];t=b.createElement(e);t.async=!0;
-                  t.src=v;s=b.getElementsByTagName(e)[0];
-                  s.parentNode.insertBefore(t,s)}(window, document,'script',
-                  'https://connect.facebook.net/en_US/fbevents.js');
-                  fbq('init', '` + process.env.NEXT_PUBLIC_META_PIXEL_ID + `');
-                  fbq('track', 'PageView');
-                `
-              }}
-            />
-            <noscript>
-              <img 
-                height="1" 
-                width="1" 
-                style={{display:'none'}}
-                src={`https://www.facebook.com/tr?id=${process.env.NEXT_PUBLIC_META_PIXEL_ID}&ev=PageView&noscript=1`}
-              />
-            </noscript>
-            {/* End Meta Pixel Code */}
-          </>
-        )}
       </head>
       <body className={`${radioCanadaBig.variable} ${sourceSerif4.variable}`}>
+        {/* Route-aware Meta Pixel: shared Niku pixel everywhere, dedicated
+            soumissionconfort pixel on the /analysis funnel only (Phase 2 V2).
+            Replaces the old inline <script> that loaded a single pixel. */}
+        <MetaPixelRouter />
         <LanguageProvider>{children}</LanguageProvider>
         <Analytics />
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,7 +74,7 @@ export default function HomePage() {
   useEffect(() => {
     initializeMeta()
     if (isMetaConfigured()) {
-      trackViewContent('Homepage', 'website').catch(() => {})
+      trackViewContent({ contentName: 'Homepage', contentType: 'website' }).catch(() => {})
     }
   }, [])
 

--- a/app/soumission-rapide/merci/page.tsx
+++ b/app/soumission-rapide/merci/page.tsx
@@ -68,12 +68,6 @@ export default function MerciPage() {
       if (stored) setLeadData(JSON.parse(stored))
     } catch { /* ignore */ }
 
-    if (typeof window.fbq === "function") {
-      window.fbq("track", "CompleteRegistration", {
-        content_name: "soumission-rapide-isolation",
-        currency: "CAD",
-      })
-    }
     if (typeof window.gtag === "function") {
       window.gtag("event", "conversion", { event_category: "pSEO Questionnaire", event_label: "merci_page_view" })
       window.gtag("event", "merci_page_view", { event_category: "pSEO Questionnaire" })

--- a/app/soumission-rapide/questionnaire/page.tsx
+++ b/app/soumission-rapide/questionnaire/page.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 import { Suspense, useState, useEffect, useCallback, useRef } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
+import { META_PIXEL_PARTAGE } from "@/components/meta-pixel-router"
 import Link from "next/link"
 import { ArrowLeft, CheckCircle, Loader2, MapPin } from "lucide-react"
 import { getCurrentUTMParameters, type UTMParameters } from "@/lib/utm-utils"
@@ -99,8 +100,16 @@ function trackStepEvent(stepNumber: number, stepName: string, stepValue: string)
       step_value: stepValue,
     })
   }
-  if (typeof window !== "undefined" && typeof window.fbq === "function") {
-    window.fbq("trackCustom", "QuestionnaireStep", {
+  // trackSingleCustom targets the SHARED pixel only — a plain trackCustom()
+  // would also reach the dedicated soumissionconfort pixel if the user crossed
+  // /analysis earlier this session.
+  if (
+    typeof window !== "undefined" &&
+    typeof window.fbq === "function" &&
+    META_PIXEL_PARTAGE &&
+    !/^X+$/i.test(META_PIXEL_PARTAGE)
+  ) {
+    window.fbq("trackSingleCustom", META_PIXEL_PARTAGE, "QuestionnaireStep", {
       step_number: stepNumber,
       step_name: stepName,
       step_value: stepValue,
@@ -358,9 +367,15 @@ function QuestionnaireContent() {
       }
 
       // Meta Pixel — Lead event (fire client-side regardless of when the
-      // API call happens; final dedup via server-side eventId).
-      if (typeof window.fbq === "function") {
-        window.fbq("track", "Lead", {
+      // API call happens; final dedup via server-side eventId). trackSingle
+      // targets the SHARED pixel only so this soumission-rapide Lead never
+      // reaches the dedicated isolation pixel.
+      if (
+        typeof window.fbq === "function" &&
+        META_PIXEL_PARTAGE &&
+        !/^X+$/i.test(META_PIXEL_PARTAGE)
+      ) {
+        window.fbq("trackSingle", META_PIXEL_PARTAGE, "Lead", {
           currency: "CAD",
           content_name: "isolation-soumission-rapide",
           ...(utmParams.utm_source && { utm_source: utmParams.utm_source }),

--- a/app/subventions/page.tsx
+++ b/app/subventions/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { useRouter } from "next/navigation"
+import { META_PIXEL_PARTAGE } from "@/components/meta-pixel-router"
 import { AddressInput } from "@/components/address-input"
 import { HowItWorks } from "@/components/how-it-works"
 import { ReviewsSection } from "@/components/reviews-section"
@@ -224,10 +225,19 @@ export default function SubventionsPage() {
     const eventId = crypto.randomUUID()
 
     try {
-      // Fire Meta Pixel (client-side) with shared eventId for dedup
-      if (typeof window !== "undefined" && (window as any).fbq) {
+      // Fire Meta Pixel (client-side) with shared eventId for dedup.
+      // trackSingle targets the SHARED pixel only — a plain track() would also
+      // hit the dedicated soumissionconfort pixel if the user crossed /analysis
+      // earlier this session, polluting the isolation audience.
+      if (
+        typeof window !== "undefined" &&
+        typeof (window as any).fbq === "function" &&
+        META_PIXEL_PARTAGE &&
+        !/^X+$/i.test(META_PIXEL_PARTAGE)
+      ) {
         ;(window as any).fbq(
-          "track",
+          "trackSingle",
+          META_PIXEL_PARTAGE,
           "Lead",
           { service_type: "subvention" },
           { eventID: eventId }

--- a/app/thermopompes/page.tsx
+++ b/app/thermopompes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
+import { META_PIXEL_PARTAGE } from "@/components/meta-pixel-router"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -264,9 +265,17 @@ export default function ThermopompesPage() {
     // Generate shared eventId for client/server deduplication
     const eventId = crypto.randomUUID();
 
-    // Facebook Pixel tracking (client-side) — fire before API for reliability
-    if (typeof window !== 'undefined' && (window as any).fbq) {
-      (window as any).fbq('track', 'Lead', {
+    // Facebook Pixel tracking (client-side) — fire before API for reliability.
+    // trackSingle targets the SHARED pixel only: a plain track() would fan out
+    // to the dedicated soumissionconfort pixel too if the user crossed the
+    // /analysis funnel earlier this session, polluting the isolation audience.
+    if (
+      typeof window !== 'undefined'
+      && typeof (window as any).fbq === 'function'
+      && META_PIXEL_PARTAGE
+      && !/^X+$/i.test(META_PIXEL_PARTAGE)
+    ) {
+      (window as any).fbq('trackSingle', META_PIXEL_PARTAGE, 'Lead', {
         service_type: 'thermopompe'
       }, { eventID: eventId });
     }

--- a/app/verifier-telephone/page.tsx
+++ b/app/verifier-telephone/page.tsx
@@ -5,6 +5,13 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { CheckCircle, Loader2 } from "lucide-react"
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp"
+import { META_PIXEL_DEDIE } from "@/components/meta-pixel-router"
+
+declare global {
+  interface Window {
+    fbq: (...args: any[]) => void
+  }
+}
 
 type State = "sending" | "pending" | "confirming" | "submitting" | "verified" | "error"
 
@@ -178,6 +185,38 @@ export default function VerifierTelephonePage() {
           setState("error")
         }
         return
+      }
+
+      // OTP confirmed + lead persisted → NOW fire the Meta browser Lead.
+      // /verifier-telephone is shared across funnels, but only the analysis
+      // lead form stashes `meta.intent`, so this gate fires for isolation leads
+      // ONLY (thermopompes/subventions payloads have no meta.intent). For those
+      // analysis leads, MetaPixelRouter has loaded the dedicated pixel
+      // (otp-verify.source==='analysis'); we still target it explicitly with
+      // trackSingle. Same eventId as the CAPI Lead (/api/leads) → Meta dedups.
+      try {
+        const pendingRaw = sessionStorage.getItem("pending-lead")
+        if (pendingRaw) {
+          const pending = JSON.parse(pendingRaw)
+          if (
+            pending?.meta?.intent === "qualified" &&
+            typeof window !== "undefined" &&
+            typeof window.fbq === "function" &&
+            META_PIXEL_DEDIE &&
+            !/^X+$/i.test(META_PIXEL_DEDIE)
+          ) {
+            const leadEventId =
+              pending.eventId ||
+              ("randomUUID" in crypto ? crypto.randomUUID() : `lead-${Date.now()}`)
+            window.fbq("trackSingle", META_PIXEL_DEDIE, "Lead", {
+              value: Number(pending.meta.estimatedValue || 0).toFixed(2),
+              currency: "CAD",
+              service_type: "isolation",
+            }, { eventID: leadEventId })
+          }
+        }
+      } catch (err) {
+        console.warn("post-OTP Lead pixel failed", err)
       }
 
       setState("verified")

--- a/components/insulation-results.tsx
+++ b/components/insulation-results.tsx
@@ -195,29 +195,6 @@ export function InsulationResults({ roofData, userAnswers, leadData, onComplete 
 
       {/* Trust Badges Section */}
       <TrustBadges />
-
-      {/* CTA Final */}
-      <div className="bg-[#f7fceb] border-2 border-[#b9e15c] rounded-[20px] shadow-md p-8 text-center">
-        <h3 className="font-heading text-2xl font-bold text-[#10002c] mb-4">
-          Prêt à économiser sur vos factures de chauffage?
-        </h3>
-        <p className="font-serif-body text-[#375371] mb-6 max-w-2xl mx-auto">
-          Obtenez des soumissions détaillées de 3 entrepreneurs certifiés dans votre région.
-          Comparez les prix, les garanties et choisissez le meilleur pour votre projet.
-        </p>
-        <button
-          onClick={() => {
-            track('Get Quotes CTA Clicked', { location: 'final_cta' })
-            onComplete()
-          }}
-          className="bg-[#b9e15c] border-2 border-[#002042] text-[#002042] font-heading font-bold py-5 px-12 rounded-full shadow-[-2px_4px_0_0_#002042] hover:shadow-[-1px_2px_0_0_#002042] hover:translate-y-0.5 transition-all text-lg"
-        >
-          Obtenir mes 3 soumissions gratuites
-        </button>
-        <p className="font-serif-body text-sm text-[#375371] mt-4">
-          ⏱️ 24-48h • 🔒 100% gratuit • 📞 Aucune obligation
-        </p>
-      </div>
     </div>
   )
 }

--- a/components/lead-capture-form.tsx
+++ b/components/lead-capture-form.tsx
@@ -1,36 +1,121 @@
 "use client"
 
-import React, { useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
+import { Loader2, Shield, CheckCircle } from "lucide-react"
+import { track } from '@vercel/analytics'
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
 import { OTP_ENABLED } from "@/lib/feature-flags"
 import { PhoneInput } from "@/components/phone-input"
 import { isValidQuebecPhone } from "@/lib/phone"
+import { getCurrentUTMParameters, type UTMParameters } from "@/lib/utm-utils"
+import { mapV2SymptomsToV1, type V2Answers } from "@/lib/funnel-config"
+import { calculateInsulationPricing } from "@/lib/insulation-calculator"
+
+declare global {
+  interface Window {
+    fbq: (...args: any[]) => void
+  }
+}
+
+export interface LeadData {
+  firstName: string
+  lastName: string
+  email: string
+  phone: string
+  leadId?: string
+}
 
 interface LeadCaptureFormProps {
   roofData: any
-  userAnswers: any
-  leadData: any
-  onComplete: (pricingData: any) => void
+  v2Answers: V2Answers
+  onComplete: (pricingData: any, leadData: LeadData, leadId: string) => void
 }
 
-export function LeadCaptureForm({ roofData, userAnswers, leadData, onComplete }: LeadCaptureFormProps) {
+function buildV1AnswersForPricing(v2: V2Answers) {
+  return {
+    // V1 defaults conservateurs — pricing reste générique sur ces axes Phase 1.
+    heatingSystem: 'electricite',
+    currentInsulation: 'partielle',
+    atticAccess: 'facile',
+    identifiedProblems: mapV2SymptomsToV1(v2.symptoms),
+  }
+}
+
+export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCaptureFormProps) {
   const router = useRouter()
+  const firstNameRef = useRef<HTMLInputElement | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [utmParams, setUtmParams] = useState<UTMParameters>({})
   const [formData, setFormData] = useState({
     firstName: "",
     lastName: "",
     email: "",
-    phone: ""
+    phone: "",
   })
+
+  useEffect(() => {
+    setUtmParams(getCurrentUTMParameters())
+    // Focus first input on mount for a11y (P2-3).
+    firstNameRef.current?.focus()
+  }, [])
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData((prev) => ({ ...prev, [e.target.name]: e.target.value }))
+  }
+
+  const isFormValid = Boolean(
+    formData.firstName.trim() &&
+    formData.lastName.trim() &&
+    formData.email.trim() &&
+    isValidQuebecPhone(formData.phone)
+  )
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    if (!isFormValid || isSubmitting) return
+    setErrorMessage(null)
     setIsSubmitting(true)
 
+    track('Lead Form Submitted', { intent: v2Answers.intent })
+
+    const v1ForPricing = buildV1AnswersForPricing(v2Answers)
     const clientLeadId = `LEAD${Date.now()}${Math.random().toString(36).substring(2, 10)}`
+    const eventId = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `evt-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+    // Pricing calc with V1 mapping — degraded but compatible (P0-3).
+    let pricingData: any
+    try {
+      pricingData = calculateInsulationPricing({
+        roofArea: roofData?.roofArea || 2000,
+        roofPitch: roofData?.pitch,
+        currentInsulation: v1ForPricing.currentInsulation,
+        atticAccess: v1ForPricing.atticAccess,
+        heatingSystem: v1ForPricing.heatingSystem,
+        identifiedProblems: v1ForPricing.identifiedProblems,
+      })
+    } catch (pricingError) {
+      console.error('💥 Pricing calculation error in LeadCaptureForm:', pricingError)
+      setErrorMessage("Une erreur est survenue lors du calcul. Réessaie dans un instant.")
+      setIsSubmitting(false)
+      return
+    }
+
+    // Backward-compatible payload (P0-4): V1 defaults + V2 passthrough.
+    const userAnswersPayload = {
+      heatingSystem: v1ForPricing.heatingSystem,
+      currentInsulation: v1ForPricing.currentInsulation,
+      atticAccess: v1ForPricing.atticAccess,
+      identifiedProblems: v1ForPricing.identifiedProblems,
+      // V2 passthrough — Phase 2 wires these into GHL/Make.
+      symptoms: v2Answers.symptoms,
+      hydroBracket: v2Answers.hydroBracket,
+      intent: v2Answers.intent,
+    }
+
     const leadPayload = {
       firstName: formData.firstName,
       lastName: formData.lastName,
@@ -38,139 +123,192 @@ export function LeadCaptureForm({ roofData, userAnswers, leadData, onComplete }:
       phone: formData.phone,
       leadId: clientLeadId,
       roofData,
-      userAnswers,
+      userAnswers: userAnswersPayload,
+      pricingData,
+      utmParams,
+      eventId,
+    }
+
+    // Fire Meta browser Lead pixel — Phase 2 will gate this by intent === 'qualified'.
+    if (typeof window !== 'undefined' && typeof window.fbq === 'function' && pricingData?.ranges?.standard) {
+      const range = pricingData.ranges.standard
+      const estimatedValue = (range.totalCost.min + range.totalCost.max) / 2
+      window.fbq('track', 'Lead', {
+        value: estimatedValue.toFixed(2),
+        currency: 'CAD',
+        service_type: 'isolation',
+      }, { eventID: eventId })
+    }
+
+    const leadDataForReturn: LeadData = {
+      firstName: formData.firstName,
+      lastName: formData.lastName,
+      email: formData.email,
+      phone: formData.phone,
+      leadId: clientLeadId,
     }
 
     try {
       if (OTP_ENABLED) {
-        // Defer the /api/leads call until OTP is verified.
+        // Defer /api/leads to /verifier-telephone (it'll POST after OTP success).
+        // Override redirectTo to the existing /pricing URL pattern so we hit
+        // InsulationResults with the same encoded data the current funnel uses.
+        const urlData = btoa(JSON.stringify({
+          roofArea: roofData?.roofArea,
+          pitch: roofData?.pitch,
+          heatingSystem: userAnswersPayload.heatingSystem,
+          currentInsulation: userAnswersPayload.currentInsulation,
+          atticAccess: userAnswersPayload.atticAccess,
+          identifiedProblems: userAnswersPayload.identifiedProblems,
+        }))
+        const pricingUrl = `/pricing?leadId=${clientLeadId}&d=${urlData}`
         sessionStorage.setItem('pending-lead', JSON.stringify(leadPayload))
-      } else {
-        const response = await fetch('/api/leads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(leadPayload),
-        }).catch(fetchError => {
-          console.error('🔥 FETCH ERROR:', fetchError.message)
-          throw fetchError
-        })
-
-        if (!response.ok) {
-          const errorText = await response.text()
-          console.error('❌ API ERROR - Status:', response.status, errorText)
-          throw new Error(`API call failed: ${response.status}`)
-        }
+        sessionStorage.setItem('otp-verify', JSON.stringify({ phone: formData.phone, redirectTo: pricingUrl }))
+        router.push('/verifier-telephone')
+        return
       }
+
+      const response = await fetch('/api/leads', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(leadPayload),
+      })
+      if (!response.ok) {
+        const errorText = await response.text()
+        console.error('❌ /api/leads error', response.status, errorText)
+        throw new Error(`API call failed: ${response.status}`)
+      }
+      onComplete(pricingData, leadDataForReturn, clientLeadId)
     } catch (error) {
-      console.error('❌ CRITICAL ERROR submitting lead:', error)
+      console.error('❌ Lead submission error:', error)
+      setErrorMessage("Une erreur est survenue. Vérifie ta connexion et réessaie.")
     } finally {
       setIsSubmitting(false)
     }
-
-    if (OTP_ENABLED) {
-      sessionStorage.setItem('otp-verify', JSON.stringify({ phone: formData.phone, redirectTo: '/success' }))
-      router.push('/verifier-telephone')
-    } else {
-      router.push('/success')
-    }
   }
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData(prev => ({ ...prev, [e.target.name]: e.target.value }))
-  }
-
-  const isFormValid = Boolean(formData.firstName && formData.lastName && formData.email && isValidQuebecPhone(formData.phone))
-
-  if (isSubmitting) {
-    return (
-      <div className="max-w-2xl mx-auto text-center py-12">
-        <div className="w-16 h-16 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">Envoi en cours...</h2>
-        <p className="text-gray-600">Nous transmettons vos informations aux entrepreneurs</p>
-      </div>
-    )
-  }
+  const estimatedMaxSavings = roofData?.roofArea
+    ? Math.round((roofData.roofArea / 2000) * 1200)
+    : 1200
 
   return (
-    <div className="max-w-2xl mx-auto">
-      <div className="text-center mb-8">
-        <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-4">🎯 Obtenez vos soumissions</h1>
-        <p className="text-xl text-gray-600">
-          Entrez vos coordonnées pour recevoir des soumissions personnalisées de nos entrepreneurs certifiés
-        </p>
-      </div>
+    <div className="max-w-2xl mx-auto px-4 pt-3 pb-8 sm:py-[40px]">
+      <div className="bg-white rounded-[20px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] w-full flex flex-col gap-4 sm:gap-5 p-4 sm:p-6">
 
-      <Card className="shadow-2xl border-0">
-        <CardHeader className="text-center pb-4">
-          <CardTitle className="text-2xl">Vos informations de contact</CardTitle>
-        </CardHeader>
-        <CardContent className="p-8">
-          <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Prénom *</label>
-                <input
-                  type="text"
-                  name="firstName"
-                  value={formData.firstName}
-                  onChange={handleInputChange}
-                  required
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  placeholder="Jean"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Nom *</label>
-                <input
-                  type="text"
-                  name="lastName"
-                  value={formData.lastName}
-                  onChange={handleInputChange}
-                  required
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  placeholder="Dupont"
-                />
-              </div>
-            </div>
+        {/* Title */}
+        <h1 className="font-heading font-bold text-[#10002c] text-xl sm:text-2xl text-center leading-[1.2]">
+          Plus qu'une étape avant d'obtenir votre estimation
+        </h1>
 
+        {/* Cyan savings highlight */}
+        <div className="bg-[#aedee5]/30 border border-[#aedee5] rounded-xl p-3 text-center">
+          <p className="font-serif-body text-[#002042] font-semibold text-sm">
+            Selon notre analyse, vous pouvez économiser jusqu'à{' '}
+            <span className="font-bold">{estimatedMaxSavings.toLocaleString()}$ par année</span>{' '}
+            sur vos factures d'énergie.
+          </p>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3 max-w-md mx-auto w-full">
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Email *</label>
+              <label htmlFor="firstName" className="block font-serif-body font-medium text-[#375371] text-sm mb-1">
+                Prénom *
+              </label>
               <input
-                type="email"
-                name="email"
-                value={formData.email}
+                ref={firstNameRef}
+                id="firstName"
+                type="text"
+                name="firstName"
+                value={formData.firstName}
                 onChange={handleInputChange}
                 required
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                placeholder="jean.dupont@email.com"
+                placeholder="Jean"
+                className="w-full px-3 py-2 border-2 border-[#e8e8e0] rounded-lg font-serif-body text-[#002042] focus:outline-none focus:border-[#002042] transition-colors"
               />
             </div>
-
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">Téléphone *</label>
-              <PhoneInput
-                value={formData.phone}
-                onChange={(value) => setFormData((prev) => ({ ...prev, phone: value }))}
-                inputClassName="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                placeholder="(514) 555-0123"
+              <label htmlFor="lastName" className="block font-serif-body font-medium text-[#375371] text-sm mb-1">
+                Nom *
+              </label>
+              <input
+                id="lastName"
+                type="text"
+                name="lastName"
+                value={formData.lastName}
+                onChange={handleInputChange}
                 required
+                placeholder="Tremblay"
+                className="w-full px-3 py-2 border-2 border-[#e8e8e0] rounded-lg font-serif-body text-[#002042] focus:outline-none focus:border-[#002042] transition-colors"
               />
             </div>
+          </div>
 
-            <Button
-              type="submit"
-              disabled={!isFormValid}
-              className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-bold py-4 px-8 rounded-xl shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none"
-            >
-              🚀 Obtenir mes soumissions gratuites
-            </Button>
+          <div>
+            <label htmlFor="email" className="block font-serif-body font-medium text-[#375371] text-sm mb-1">
+              Courriel *
+            </label>
+            <input
+              id="email"
+              type="email"
+              name="email"
+              value={formData.email}
+              onChange={handleInputChange}
+              required
+              placeholder="jean@exemple.com"
+              className="w-full px-3 py-2 border-2 border-[#e8e8e0] rounded-lg font-serif-body text-[#002042] focus:outline-none focus:border-[#002042] transition-colors"
+            />
+          </div>
 
-            <p className="text-sm text-gray-500 text-center">
-              ⚡ Résultats instantanés • 🔒 100% sécurisé • 📞 Aucun appel non sollicité
-            </p>
-          </form>
-        </CardContent>
-      </Card>
+          <div>
+            <label className="block font-serif-body font-medium text-[#375371] text-sm mb-1">
+              Téléphone *
+            </label>
+            <PhoneInput
+              value={formData.phone}
+              onChange={(value) => setFormData((prev) => ({ ...prev, phone: value }))}
+              inputClassName="w-full px-3 py-2 border-2 border-[#e8e8e0] rounded-lg font-serif-body text-[#002042] focus:outline-none focus:border-[#002042] transition-colors"
+              placeholder="(514) 123-4567"
+              required
+            />
+          </div>
+
+          {errorMessage && (
+            <div className="bg-red-50 border-2 border-red-300 rounded-lg px-4 py-3">
+              <p className="font-serif-body text-sm text-red-700">{errorMessage}</p>
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={!isFormValid || isSubmitting}
+            className="w-full bg-[#b9e15c] border-2 border-[#002042] text-[#002042] font-heading font-bold py-4 px-6 rounded-full transition-all duration-300 shadow-[-2px_4px_0_0_#002042] hover:shadow-[-1px_2px_0_0_#002042] hover:translate-y-0.5 text-base disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none disabled:translate-y-0 mt-2"
+          >
+            {isSubmitting ? (
+              <span className="flex items-center justify-center gap-2">
+                <Loader2 className="w-5 h-5 animate-spin" />
+                Génération en cours...
+              </span>
+            ) : (
+              "Découvrir mon estimation maintenant"
+            )}
+          </button>
+        </form>
+
+        {/* Trust badges */}
+        <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 pt-3 border-t border-[#e8e8e0]">
+          <div className="flex items-center gap-1.5 font-serif-body text-sm text-[#375371]">
+            <Shield className="w-4 h-4 text-[#002042]" />
+            <span>100% Sécurisé</span>
+          </div>
+          <div className="flex items-center gap-1.5 font-serif-body text-sm text-[#375371]">
+            <CheckCircle className="w-4 h-4 text-[#002042]" />
+            <span>Entrepreneurs certifiés RBQ</span>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/components/lead-capture-form.tsx
+++ b/components/lead-capture-form.tsx
@@ -11,6 +11,7 @@ import { isValidQuebecPhone } from "@/lib/phone"
 import { getCurrentUTMParameters, type UTMParameters } from "@/lib/utm-utils"
 import { buildV1AnswersFromV2, type V2Answers } from "@/lib/funnel-config"
 import { calculateInsulationPricing } from "@/lib/insulation-calculator"
+import { META_PIXEL_DEDIE } from "@/components/meta-pixel-router"
 
 declare global {
   interface Window {
@@ -106,6 +107,12 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
       intent: v2Answers.intent,
     }
 
+    // Estimated lead value (standard range midpoint) — carried in pending.meta
+    // so /verifier-telephone can fire the post-OTP Lead pixel with the same value.
+    const estimatedValue = pricingData?.ranges?.standard
+      ? (pricingData.ranges.standard.totalCost.min + pricingData.ranges.standard.totalCost.max) / 2
+      : 0
+
     const leadPayload = {
       firstName: formData.firstName,
       lastName: formData.lastName,
@@ -116,25 +123,21 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
       userAnswers: userAnswersPayload,
       pricingData,
       utmParams,
+      // eventId stays top-level: /api/leads reads leadData.eventId for the CAPI
+      // Lead, and /verifier-telephone reads pending.eventId for the browser
+      // Lead → same id → Meta dedups browser↔CAPI (P0-3).
       eventId,
+      // Phase 2: drives the post-OTP browser Lead gate + value on /verifier-telephone.
+      meta: {
+        intent: v2Answers.intent,
+        estimatedValue,
+      },
     }
 
-    // Fire Meta browser Lead pixel ONLY for qualified intent — curious leads
-    // pollute the optim audience. Server CAPI is similarly gated Phase 2 in /api/leads.
-    if (
-      v2Answers.intent === 'qualified' &&
-      typeof window !== 'undefined' &&
-      typeof window.fbq === 'function' &&
-      pricingData?.ranges?.standard
-    ) {
-      const range = pricingData.ranges.standard
-      const estimatedValue = (range.totalCost.min + range.totalCost.max) / 2
-      window.fbq('track', 'Lead', {
-        value: estimatedValue.toFixed(2),
-        currency: 'CAD',
-        service_type: 'isolation',
-      }, { eventID: eventId })
-    }
+    // NOTE (Phase 2): the Meta browser Lead pixel is NO LONGER fired here.
+    // It moved past the OTP gate — qualified + form submitted + OTP confirmed —
+    // so we never declare a Lead for an unverified phone. Fired from
+    // /verifier-telephone (OTP path) or after /api/leads 200 (non-OTP path below).
 
     const leadDataForReturn: LeadData = {
       firstName: formData.firstName,
@@ -159,7 +162,11 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
         }))
         const pricingUrl = `/pricing?leadId=${clientLeadId}&d=${urlData}`
         sessionStorage.setItem('pending-lead', JSON.stringify(leadPayload))
-        sessionStorage.setItem('otp-verify', JSON.stringify({ phone: formData.phone, redirectTo: pricingUrl }))
+        // source:'analysis' lets MetaPixelRouter load the DEDICATED pixel on the
+        // shared /verifier-telephone page for THIS funnel only. Thermopompes /
+        // subventions leads also land on /verifier-telephone but never set this
+        // flag → they stay on the shared pixel → zero cross-funnel contamination.
+        sessionStorage.setItem('otp-verify', JSON.stringify({ phone: formData.phone, redirectTo: pricingUrl, source: 'analysis' }))
         router.push('/verifier-telephone')
         return
       }
@@ -174,6 +181,25 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
         console.error('❌ /api/leads error', response.status, errorText)
         throw new Error(`API call failed: ${response.status}`)
       }
+
+      // Non-OTP path (OTP_ENABLED=false): fire the browser Lead AFTER /api/leads
+      // succeeds — qualified intent only, same eventId as the CAPI Lead, targeted
+      // at the dedicated pixel (trackSingle). When OTP is on, this fires from
+      // /verifier-telephone instead (we return before reaching here).
+      if (
+        v2Answers.intent === 'qualified' &&
+        typeof window !== 'undefined' &&
+        typeof window.fbq === 'function' &&
+        META_PIXEL_DEDIE &&
+        !/^X+$/i.test(META_PIXEL_DEDIE)
+      ) {
+        window.fbq('trackSingle', META_PIXEL_DEDIE, 'Lead', {
+          value: estimatedValue.toFixed(2),
+          currency: 'CAD',
+          service_type: 'isolation',
+        }, { eventID: eventId })
+      }
+
       onComplete(pricingData, leadDataForReturn, clientLeadId)
     } catch (error) {
       console.error('❌ Lead submission error:', error)

--- a/components/lead-capture-form.tsx
+++ b/components/lead-capture-form.tsx
@@ -9,7 +9,7 @@ import { OTP_ENABLED } from "@/lib/feature-flags"
 import { PhoneInput } from "@/components/phone-input"
 import { isValidQuebecPhone } from "@/lib/phone"
 import { getCurrentUTMParameters, type UTMParameters } from "@/lib/utm-utils"
-import { mapV2SymptomsToV1, type V2Answers } from "@/lib/funnel-config"
+import { buildV1AnswersFromV2, type V2Answers } from "@/lib/funnel-config"
 import { calculateInsulationPricing } from "@/lib/insulation-calculator"
 
 declare global {
@@ -30,16 +30,6 @@ interface LeadCaptureFormProps {
   roofData: any
   v2Answers: V2Answers
   onComplete: (pricingData: any, leadData: LeadData, leadId: string) => void
-}
-
-function buildV1AnswersForPricing(v2: V2Answers) {
-  return {
-    // V1 defaults conservateurs — pricing reste générique sur ces axes Phase 1.
-    heatingSystem: 'electricite',
-    currentInsulation: 'partielle',
-    atticAccess: 'facile',
-    identifiedProblems: mapV2SymptomsToV1(v2.symptoms),
-  }
 }
 
 export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCaptureFormProps) {
@@ -80,7 +70,7 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
 
     track('Lead Form Submitted', { intent: v2Answers.intent })
 
-    const v1ForPricing = buildV1AnswersForPricing(v2Answers)
+    const v1ForPricing = buildV1AnswersFromV2(v2Answers)
     const clientLeadId = `LEAD${Date.now()}${Math.random().toString(36).substring(2, 10)}`
     const eventId = typeof crypto !== 'undefined' && 'randomUUID' in crypto
       ? crypto.randomUUID()
@@ -129,8 +119,14 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
       eventId,
     }
 
-    // Fire Meta browser Lead pixel — Phase 2 will gate this by intent === 'qualified'.
-    if (typeof window !== 'undefined' && typeof window.fbq === 'function' && pricingData?.ranges?.standard) {
+    // Fire Meta browser Lead pixel ONLY for qualified intent — curious leads
+    // pollute the optim audience. Server CAPI is similarly gated Phase 2 in /api/leads.
+    if (
+      v2Answers.intent === 'qualified' &&
+      typeof window !== 'undefined' &&
+      typeof window.fbq === 'function' &&
+      pricingData?.ranges?.standard
+    ) {
       const range = pricingData.ranges.standard
       const estimatedValue = (range.totalCost.min + range.totalCost.max) / 2
       window.fbq('track', 'Lead', {

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -10,8 +10,16 @@ import { usePathname } from 'next/navigation'
 // invariant: a PageView fires to EXACTLY ONE pixel per route, and the dedicated
 // soumissionconfort pixel ONLY ever sees the isolation /analysis funnel.
 //   - /analysis*                          → dedicated pixel
+//   - /pricing                            → dedicated pixel (iso results page)
 //   - /verifier-telephone (analysis only) → dedicated pixel
 //   - everything else                     → shared Niku pixel (status quo)
+//
+// /pricing is the isolation results page (InsulationResults). It's reached ONLY
+// from the analysis lead form (lead-capture-form.tsx redirects there post-OTP),
+// so unlike /verifier-telephone it's classified by pathname alone — no source
+// marker needed, no cross-funnel ambiguity. Without this, the bottom-funnel
+// results PageView would leak onto the shared pixel (otp-verify is already
+// cleared by the time we land here, so a session-marker gate wouldn't work).
 //
 // /verifier-telephone is SHARED across funnels (analysis, thermopompes,
 // subventions all router.push there). Classifying it by pathname alone would
@@ -43,9 +51,12 @@ function isPlaceholder(v: string): boolean {
 }
 
 // True for routes that are UNCONDITIONALLY part of the analysis funnel (the
-// wizard pages). /verifier-telephone is handled separately because it's shared.
+// wizard pages + the /pricing results page). /verifier-telephone is handled
+// separately because it's shared across funnels.
 export function isAnalysisWizardRoute(pathname: string): boolean {
-  return pathname === '/analysis' || pathname.startsWith('/analysis/')
+  return pathname === '/analysis'
+    || pathname.startsWith('/analysis/')
+    || pathname === '/pricing'
 }
 
 // Reads the OTP source marker the analysis lead form stamps in sessionStorage.

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useEffect, useRef } from 'react'
+import Script from 'next/script'
+import { usePathname } from 'next/navigation'
+
+// Phase 2 V2 — route-aware Meta Pixel loader.
+//
+// One <MetaPixelRouter /> is mounted once in app/layout.tsx. It guarantees the
+// invariant: a PageView fires to EXACTLY ONE pixel per route, and the dedicated
+// soumissionconfort pixel ONLY ever sees the isolation /analysis funnel.
+//   - /analysis*                          → dedicated pixel
+//   - /verifier-telephone (analysis only) → dedicated pixel
+//   - everything else                     → shared Niku pixel (status quo)
+//
+// /verifier-telephone is SHARED across funnels (analysis, thermopompes,
+// subventions all router.push there). Classifying it by pathname alone would
+// leak HVAC/subvention OTP PageViews onto the dedicated pixel. So we gate it on
+// sessionStorage `otp-verify.source === 'analysis'`, which only the analysis
+// lead form sets (components/lead-capture-form.tsx). Zero cross-funnel
+// contamination: a thermopompe lead on /verifier-telephone never sets that
+// flag → stays on the shared pixel.
+//
+// Why trackSingle (not two <Script> blocks): the fbq bootstrap starts with
+// `if(f.fbq)return`, so a second `fbq('init', X)` ADDS a pixel rather than
+// replacing it, and a plain `fbq('track', 'PageView')` then fires to BOTH
+// pixels. We init each pixel once and fire every PageView with
+// `trackSingle(<pixelId>, ...)` to the route's pixel only.
+
+// Exported so the OTHER funnels (thermopompes/subventions/soumission-rapide)
+// can fire their events with trackSingle(<shared>, ...) instead of a global
+// fbq('track', ...), which would fan out to the dedicated pixel too once a
+// user has crossed the /analysis funnel in the same session. Single source of
+// truth — call sites can't accidentally target the wrong pixel.
+export const META_PIXEL_PARTAGE = process.env.NEXT_PUBLIC_META_PIXEL_ID || ''
+const PIXEL_PARTAGE = META_PIXEL_PARTAGE
+// Exported so the wizard ViewContent + post-OTP Lead can target the dedicated
+// pixel with trackSingle (browser dedup vs CAPI).
+export const META_PIXEL_DEDIE = process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT || ''
+
+function isPlaceholder(v: string): boolean {
+  return !v || /^X+$/i.test(v)
+}
+
+// True for routes that are UNCONDITIONALLY part of the analysis funnel (the
+// wizard pages). /verifier-telephone is handled separately because it's shared.
+export function isAnalysisWizardRoute(pathname: string): boolean {
+  return pathname === '/analysis' || pathname.startsWith('/analysis/')
+}
+
+// Reads the OTP source marker the analysis lead form stamps in sessionStorage.
+// Only meaningful on /verifier-telephone, and only client-side.
+function otpSourceIsAnalysis(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    const raw = sessionStorage.getItem('otp-verify')
+    if (!raw) return false
+    return JSON.parse(raw)?.source === 'analysis'
+  } catch {
+    return false
+  }
+}
+
+// Whether the CURRENT route belongs to the isolation /analysis funnel and so
+// should load the dedicated pixel. Must run client-side (reads sessionStorage).
+export function inAnalysisFunnelClient(pathname: string): boolean {
+  if (isAnalysisWizardRoute(pathname)) return true
+  if (pathname === '/verifier-telephone') return otpSourceIsAnalysis()
+  return false
+}
+
+export function MetaPixelRouter() {
+  const pathname = usePathname()
+  // Track which pixels we've already `init`-ed so we never double-init.
+  const initedRef = useRef<Set<string>>(new Set())
+  // Guard against StrictMode double-effect / duplicate PageView per route.
+  const lastPageViewRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.fbq !== 'function') return
+
+    const inFunnel = inAnalysisFunnelClient(pathname)
+    // Strict guard (Zack v2 décision 5): on the /analysis funnel, if the
+    // dedicated pixel is missing/placeholder, fire NOTHING — never leak the
+    // funnel onto the shared pixel during rollout.
+    const pixelForRoute = inFunnel ? META_PIXEL_DEDIE : PIXEL_PARTAGE
+    if (isPlaceholder(pixelForRoute)) return
+
+    // Init this pixel once (idempotent across navigations).
+    if (!initedRef.current.has(pixelForRoute)) {
+      window.fbq('init', pixelForRoute)
+      initedRef.current.add(pixelForRoute)
+    }
+
+    // Fire PageView to THIS pixel only — never the other one. The dedupe key
+    // pins it to (pixel, pathname) so StrictMode's double effect doesn't send
+    // two PageViews for the same route in dev.
+    const pageViewKey = `${pixelForRoute}:${pathname}`
+    if (lastPageViewRef.current !== pageViewKey) {
+      lastPageViewRef.current = pageViewKey
+      window.fbq('trackSingle', pixelForRoute, 'PageView')
+    }
+  }, [pathname])
+
+  // The bootstrap snippet loads the fbq library exactly once for the whole
+  // app. We deliberately do NOT call fbq('init'/'track') inside it — the
+  // useEffect above owns init + PageView so the single-pixel invariant holds
+  // on every route, including the very first paint.
+  if (isPlaceholder(PIXEL_PARTAGE) && isPlaceholder(META_PIXEL_DEDIE)) return null
+
+  return (
+    <>
+      <Script id="meta-pixel-bootstrap" strategy="afterInteractive">
+        {`
+          !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+          n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+          n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+          document,'script','https://connect.facebook.net/en_US/fbevents.js');
+        `}
+      </Script>
+      {/* noscript fallback uses the shared pixel — the no-JS case never reaches
+          the SPA /analysis funnel anyway (no wizard, no lead form). */}
+      {!isPlaceholder(PIXEL_PARTAGE) && (
+        <noscript>
+          <img height="1" width="1" style={{ display: 'none' }}
+            src={`https://www.facebook.com/tr?id=${PIXEL_PARTAGE}&ev=PageView&noscript=1`} alt="" />
+        </noscript>
+      )}
+    </>
+  )
+}

--- a/components/user-questionnaire-wizard.tsx
+++ b/components/user-questionnaire-wizard.tsx
@@ -13,6 +13,13 @@ import {
   type HydroBracketCode,
   type IntentCode,
 } from "@/lib/funnel-config"
+import { META_PIXEL_DEDIE } from "@/components/meta-pixel-router"
+
+declare global {
+  interface Window {
+    fbq: (...args: any[]) => void
+  }
+}
 
 interface UserQuestionnaireProps {
   roofData: any
@@ -42,6 +49,49 @@ export function UserQuestionnaire({ roofData: _roofData, onComplete }: UserQuest
     return () => {
       if (advanceTimeoutRef.current) clearTimeout(advanceTimeoutRef.current)
     }
+  }, [])
+
+  // ViewContent fires ONCE when the wizard mounts — this is the moment the user
+  // "starts the application" (after the roof-analysis loading). Browser fbq +
+  // CAPI share the same eventId so Meta dedups to 1 event. Dedicated pixel only
+  // (we're on /analysis → MetaPixelRouter has loaded the dedicated pixel; we
+  // target it explicitly with trackSingleCustom to stay isolated even if the
+  // shared pixel is also initialised from a prior route).
+  const viewContentFiredRef = useRef(false)
+  useEffect(() => {
+    if (viewContentFiredRef.current) return
+    viewContentFiredRef.current = true
+
+    const eventId = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `vc-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+    // Browser pixel ViewContent → dedicated pixel only. ViewContent is a Meta
+    // STANDARD event, so it's trackSingle (not trackSingleCustom).
+    if (
+      typeof window !== 'undefined'
+      && typeof window.fbq === 'function'
+      && META_PIXEL_DEDIE
+      && !/^X+$/i.test(META_PIXEL_DEDIE)
+    ) {
+      window.fbq('trackSingle', META_PIXEL_DEDIE, 'ViewContent', {
+        content_name: 'analysis-wizard-v2',
+        content_category: 'isolation',
+      }, { eventID: eventId })
+    }
+
+    // CAPI ViewContent → dedicated pixel (server-side), dedup via same eventId.
+    // keepalive guards against the event being dropped if the user navigates
+    // away quickly after mount.
+    fetch('/api/meta/view-content', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventId,
+        sourceUrl: typeof window !== 'undefined' ? window.location.href : undefined,
+      }),
+      keepalive: true,
+    }).catch(err => console.warn('ViewContent CAPI failed', err))
   }, [])
 
   const totalSteps = STEP_KEYS.length

--- a/components/user-questionnaire-wizard.tsx
+++ b/components/user-questionnaire-wizard.tsx
@@ -1,544 +1,254 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import { LeadCapturePopup, type LeadData } from "@/components/lead-capture-popup"
-import { getCurrentUTMParameters, type UTMParameters } from "@/lib/utm-utils"
-import { OTP_ENABLED } from "@/lib/feature-flags"
+import { useState, useEffect, useRef } from "react"
 import { ArrowLeft, Check, CheckCircle, Smile } from "lucide-react"
 import { track } from '@vercel/analytics'
 
-declare global {
-  interface Window {
-    fbq: (...args: any[]) => void;
-  }
-}
+import {
+  SYMPTOMS_OPTIONS,
+  HYDRO_BRACKETS,
+  INTENT_OPTIONS,
+  type V2Answers,
+  type SymptomCode,
+  type HydroBracketCode,
+  type IntentCode,
+} from "@/lib/funnel-config"
 
 interface UserQuestionnaireProps {
   roofData: any
-  onComplete: (answers: any, leadData: LeadData, pricingData: any) => void
+  onComplete: (answers: V2Answers) => void
 }
 
-export function UserQuestionnaire({ roofData, onComplete }: UserQuestionnaireProps) {
-  const [showLeadCapture, setShowLeadCapture] = useState(false)
-  const [isSubmittingLead, setIsSubmittingLead] = useState(false)
+const STEP_KEYS = ['symptoms', 'hydroBracket', 'intent'] as const
+const STEP_TITLES = [
+  { title: "Quels symptômes vis-tu chez toi ?", description: "Coche tous ceux qui s'appliquent — minimum 1." },
+  { title: "Combien tu paies d'Hydro par mois en moyenne ?", description: "Pas sûr du montant exact ? Donne ton meilleur estimé." },
+  { title: "Pourquoi tu fais cette demande ?", description: "Ça nous aide à t'envoyer la bonne info." },
+] as const
+
+export function UserQuestionnaire({ roofData: _roofData, onComplete }: UserQuestionnaireProps) {
   const [currentStep, setCurrentStep] = useState(0)
-  const [utmParams, setUtmParams] = useState<UTMParameters>({})
-  const [answers, setAnswers] = useState({
-    heatingSystem: "",
-    currentInsulation: "",
-    atticAccess: "",
-    identifiedProblems: [] as string[],
+  const [answers, setAnswers] = useState<V2Answers>({
+    symptoms: [],
+    hydroBracket: '',
+    intent: '',
   })
 
-  // Extract UTM parameters on component mount
+  // Click guard prevents double-advance race condition (P1-5).
+  const [isAdvancing, setIsAdvancing] = useState(false)
+  const advanceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   useEffect(() => {
-    const params = getCurrentUTMParameters()
-    setUtmParams(params)
+    return () => {
+      if (advanceTimeoutRef.current) clearTimeout(advanceTimeoutRef.current)
+    }
   }, [])
 
-  const steps = [
-    { 
-      title: "Système de chauffage principal", 
-      description: "Quel est votre système de chauffage principal?",
-      key: "heatingSystem" 
-    },
-    { 
-      title: "État de l'isolation", 
-      description: "Quelle est la situation actuelle de votre isolation?",
-      key: "currentInsulation" 
-    },
-    { 
-      title: "Accès à l'entre-toit", 
-      description: "Comment est l'accès à votre entre-toit?",
-      key: "atticAccess" 
-    },
-    { 
-      title: "Problèmes identifiés", 
-      description: "Avez-vous identifié des problèmes? (optionnel)",
-      key: "identifiedProblems" 
-    },
-  ]
+  const totalSteps = STEP_KEYS.length
+  const getProgress = () => ((currentStep + 1) / totalSteps) * 100
 
-  const getProgress = () => {
-    return ((currentStep + 1) / steps.length) * 100
-  }
-
-  const canGoNext = () => {
-    switch (currentStep) {
-      case 0:
-        return !!answers.heatingSystem
-      case 1:
-        return !!answers.currentInsulation
-      case 2:
-        return !!answers.atticAccess
-      case 3:
-        return true // Problems step is optional
-      default:
-        return false
-    }
-  }
-
-  const handleNext = () => {
-    // Track step completion
+  const trackStepCompleted = (stepIndex: number) => {
     track('Questionnaire Step Completed', {
-      step: currentStep + 1,
-      stepName: steps[currentStep].key
+      step: stepIndex + 1,
+      stepName: STEP_KEYS[stepIndex],
     })
-    
-    if (currentStep < steps.length - 1) {
-      setCurrentStep(currentStep + 1)
-    } else {
-      track('Questionnaire Completed')
-      handleGetPricing()
-    }
   }
 
-  const handlePrevious = () => {
-    if (currentStep > 0) {
-      setCurrentStep(currentStep - 1)
-    }
-  }
-
-  // Auto-advance for radio steps (0-2)
-  const selectAndAdvance = (field: 'heatingSystem' | 'currentInsulation' | 'atticAccess', value: string) => {
-    setAnswers((prev) => ({ ...prev, [field]: value }))
-    setTimeout(() => {
-      track('Questionnaire Step Completed', { step: currentStep + 1, stepName: steps[currentStep].key })
-      setCurrentStep((s) => s + 1)
+  const advanceTo = (nextStep: number, stepCompletedIndex: number) => {
+    if (isAdvancing) return
+    setIsAdvancing(true)
+    advanceTimeoutRef.current = setTimeout(() => {
+      trackStepCompleted(stepCompletedIndex)
+      if (nextStep >= totalSteps) {
+        // Finished — hand answers up. Wrap in a fresh ref snapshot to satisfy
+        // the V2Answers contract (intent narrowed away from '').
+        const finalAnswers: V2Answers = { ...answers }
+        track('Questionnaire Completed')
+        track('Lead Form Shown', { intent: finalAnswers.intent })
+        onComplete(finalAnswers)
+      } else {
+        setCurrentStep(nextStep)
+      }
+      setIsAdvancing(false)
     }, 250)
   }
 
-  const isFormValid = () => {
-    return (
-      answers.heatingSystem &&
-      answers.currentInsulation &&
-      answers.atticAccess
-    )
+  const handlePrevious = () => {
+    if (isAdvancing) return
+    if (currentStep > 0) setCurrentStep(currentStep - 1)
   }
 
-  const handleGetPricing = () => {
-    if (isFormValid()) {
-      track('Lead Capture Popup Opened')
-      setShowLeadCapture(true)
-    }
+  const handleSymptomToggle = (code: SymptomCode) => {
+    setAnswers((prev) => {
+      const has = prev.symptoms.includes(code)
+      return {
+        ...prev,
+        symptoms: has ? prev.symptoms.filter((s) => s !== code) : [...prev.symptoms, code],
+      }
+    })
   }
 
-  const handleProblemToggle = (problemValue: string) => {
-    const current = answers.identifiedProblems || []
-    const newProblems = current.includes(problemValue)
-      ? current.filter((p) => p !== problemValue)
-      : [...current, problemValue]
-    setAnswers((prev) => ({ ...prev, identifiedProblems: newProblems }))
+  const handleSymptomNext = () => {
+    if (answers.symptoms.length === 0) return
+    advanceTo(1, 0)
   }
 
-  const handleLeadSubmit = async (leadData: LeadData) => {
-    setIsSubmittingLead(true)
-
-    try {
-      // First calculate pricing
-      let pricingData = null
-      
-      try {
-        // Utiliser le calculateur d'isolation côté client
-        const { calculateInsulationPricing } = await import('@/lib/insulation-calculator')
-        
-        const calculationInputs = {
-          roofArea: roofData.roofArea || 2000,
-          roofPitch: roofData.pitch,
-          currentInsulation: answers.currentInsulation || 'partielle',
-          atticAccess: answers.atticAccess || 'facile',
-          heatingSystem: answers.heatingSystem || 'electricite',
-          identifiedProblems: answers.identifiedProblems || [],
-        }
-        
-        pricingData = calculateInsulationPricing(calculationInputs)
-        
-      } catch (pricingError) {
-        console.error('💥 Pricing calculation error, using fallback:', pricingError)
-        const area = roofData?.roofArea || 1500
-        pricingData = {
-          adjustedArea: area,
-          ranges: {
-            economique: {
-              name: 'Économique', type: 'Cellulose soufflée', rValue: 50,
-              thickness: '14 pouces', durability: '20-30 ans', icon: '🥉',
-              features: ['Valeur R: 3,6-3,8 par pouce', 'Matériau 100% recyclé', 'Installation rapide'],
-              totalCost: { min: Math.max(1500, Math.round(area * 0.90)), max: Math.round(area * 1.50) },
-              annualSavings: { min: 350, max: 600 },
-              heatingReduction: { min: 15, max: 25 },
-              paybackPeriod: { min: 3, max: 6 },
-              savings25Years: { min: 8750, max: 15000 },
-              netGain25Years: { min: 5000, max: 12000 },
-            },
-            standard: {
-              name: 'Standard', type: 'Fibre de verre soufflée', rValue: 55,
-              thickness: '18 pouces', durability: '20-25 ans', icon: '🥈',
-              features: ['Valeur R: 2,6-2,9 par pouce', 'Non combustible', 'Installation certifiée RBQ'],
-              totalCost: { min: Math.max(2000, Math.round(area * 1.40)), max: Math.round(area * 2.80) },
-              annualSavings: { min: 450, max: 750 },
-              heatingReduction: { min: 20, max: 35 },
-              paybackPeriod: { min: 3, max: 6 },
-              savings25Years: { min: 11250, max: 18750 },
-              netGain25Years: { min: 6000, max: 15000 },
-            },
-            premium: {
-              name: 'Premium', type: 'Hybride : mousse projetée + soufflé', rValue: 60,
-              thickness: '12 pouces', durability: '30-50 ans', icon: '🥇',
-              features: ['Valeur R: 6,0+ par pouce (mousse)', 'Barrière d\'air et d\'humidité', 'Performance maximale'],
-              totalCost: { min: Math.max(3500, Math.round(area * 3.00)), max: Math.round(area * 5.00) },
-              annualSavings: { min: 600, max: 1000 },
-              heatingReduction: { min: 25, max: 45 },
-              paybackPeriod: { min: 5, max: 10 },
-              savings25Years: { min: 15000, max: 25000 },
-              netGain25Years: { min: 8000, max: 20000 },
-            },
-          }
-        }
-      }
-
-      // Generate shared eventId for client/server deduplication
-      const eventId = crypto.randomUUID();
-
-      // Fire Meta Pixel event (client-side)
-      if (typeof window.fbq === 'function' && pricingData?.ranges?.standard) {
-        const standardRange = pricingData.ranges.standard
-        const estimatedValue = (standardRange.totalCost.min + standardRange.totalCost.max) / 2;
-        window.fbq('track', 'Lead', {
-            value: estimatedValue.toFixed(2),
-            currency: 'CAD',
-            service_type: 'isolation'
-        }, { eventID: eventId });
-      }
-
-      // Pre-generate a client lead ID so the funnel can route to /pricing
-      // before /api/leads is actually called (when OTP_ENABLED=true, the
-      // POST is deferred until after OTP success on /verifier-telephone).
-      const clientLeadId = `LEAD${Date.now()}${Math.random().toString(36).substring(2, 10)}`
-
-      // Now prepare complete lead data with pricing included
-      const leadPayload = {
-        firstName: leadData.firstName,
-        lastName: leadData.lastName,
-        email: leadData.email,
-        phone: leadData.phone,
-        leadId: clientLeadId,
-        roofData,
-        userAnswers: answers,
-        pricingData,
-        utmParams,
-        eventId
-      }
-
-      if (OTP_ENABLED) {
-        // Defer the submission: stash the payload, then let /verifier-telephone
-        // submit it (with otpToken) after Twilio confirms the SMS code.
-        sessionStorage.setItem('pending-lead', JSON.stringify(leadPayload))
-        sessionStorage.setItem('otp-verify', JSON.stringify({ phone: leadData.phone, redirectTo: '/success' }))
-      } else {
-        const response = await fetch('/api/leads', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(leadPayload),
-        })
-
-        if (!response.ok) {
-          const errorText = await response.text()
-          console.error('❌ API ERROR - Status:', response.status)
-          console.error('❌ API ERROR - Text:', errorText)
-          throw new Error(`API call failed: ${response.status}`)
-        }
-      }
-
-      const leadDataWithId = {
-        ...leadData,
-        leadId: clientLeadId
-      }
-
-      setShowLeadCapture(false)
-      onComplete(answers, leadDataWithId, pricingData)
-      
-    } catch (error) {
-      console.error('❌ CRITICAL ERROR in popup submission:', error)
-      console.error('❌ Error details:', {
-        message: error instanceof Error ? error.message : 'Unknown error',
-        stack: error instanceof Error ? error.stack : 'No stack trace',
-        name: error instanceof Error ? error.name : 'Unknown error type'
-      })
-      const area = roofData?.roofArea || 1500
-      const fallbackPricing = {
-        adjustedArea: area,
-        ranges: {
-          economique: {
-            name: 'Économique', type: 'Cellulose soufflée', rValue: 50,
-            thickness: '14 pouces', durability: '20-30 ans', icon: '🥉',
-            features: ['Valeur R: 3,6-3,8 par pouce', 'Matériau 100% recyclé', 'Installation rapide'],
-            totalCost: { min: Math.max(1500, Math.round(area * 0.90)), max: Math.round(area * 1.50) },
-            annualSavings: { min: 350, max: 600 },
-            heatingReduction: { min: 15, max: 25 },
-            paybackPeriod: { min: 3, max: 6 },
-            savings25Years: { min: 8750, max: 15000 },
-            netGain25Years: { min: 5000, max: 12000 },
-          },
-          standard: {
-            name: 'Standard', type: 'Fibre de verre soufflée', rValue: 55,
-            thickness: '18 pouces', durability: '20-25 ans', icon: '🥈',
-            features: ['Valeur R: 2,6-2,9 par pouce', 'Non combustible', 'Installation certifiée RBQ'],
-            totalCost: { min: Math.max(2000, Math.round(area * 1.40)), max: Math.round(area * 2.80) },
-            annualSavings: { min: 450, max: 750 },
-            heatingReduction: { min: 20, max: 35 },
-            paybackPeriod: { min: 3, max: 6 },
-            savings25Years: { min: 11250, max: 18750 },
-            netGain25Years: { min: 6000, max: 15000 },
-          },
-          premium: {
-            name: 'Premium', type: 'Hybride : mousse projetée + soufflé', rValue: 60,
-            thickness: '12 pouces', durability: '30-50 ans', icon: '🥇',
-            features: ['Valeur R: 6,0+ par pouce (mousse)', 'Barrière d\'air et d\'humidité', 'Performance maximale'],
-            totalCost: { min: Math.max(3500, Math.round(area * 3.00)), max: Math.round(area * 5.00) },
-            annualSavings: { min: 600, max: 1000 },
-            heatingReduction: { min: 25, max: 45 },
-            paybackPeriod: { min: 5, max: 10 },
-            savings25Years: { min: 15000, max: 25000 },
-            netGain25Years: { min: 8000, max: 20000 },
-          },
-        }
-      }
-      const fallbackLeadId = `LEAD${Date.now()}${Math.random().toString(36).substring(2, 10)}`
-      const fallbackPayload = {
-        firstName: leadData.firstName,
-        lastName: leadData.lastName,
-        email: leadData.email,
-        phone: leadData.phone,
-        leadId: fallbackLeadId,
-        roofData,
-        userAnswers: answers,
-        pricingData: fallbackPricing,
-        utmParams,
-      }
-      if (OTP_ENABLED) {
-        sessionStorage.setItem('pending-lead', JSON.stringify(fallbackPayload))
-        sessionStorage.setItem('otp-verify', JSON.stringify({ phone: leadData.phone, redirectTo: '/success' }))
-      } else {
-        try {
-          await fetch('/api/leads', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(fallbackPayload),
-          })
-        } catch (fallbackErr) {
-          console.error('❌ Fallback lead submission failed:', fallbackErr)
-        }
-      }
-      setShowLeadCapture(false)
-      onComplete(answers, { ...leadData, leadId: fallbackLeadId }, fallbackPricing)
-    } finally {
-      setIsSubmittingLead(false)
-    }
+  const handleHydroSelect = (code: HydroBracketCode) => {
+    setAnswers((prev) => ({ ...prev, hydroBracket: code }))
+    advanceTo(2, 1)
   }
+
+  const handleIntentSelect = (code: IntentCode) => {
+    setAnswers((prev) => ({ ...prev, intent: code }))
+    // Use a microtask trick: we need the latest answers when calling onComplete.
+    // Easiest: capture inline.
+    if (isAdvancing) return
+    setIsAdvancing(true)
+    advanceTimeoutRef.current = setTimeout(() => {
+      trackStepCompleted(2)
+      const finalAnswers: V2Answers = { ...answers, intent: code }
+      track('Questionnaire Completed')
+      track('Lead Form Shown', { intent: finalAnswers.intent })
+      onComplete(finalAnswers)
+      setIsAdvancing(false)
+    }, 250)
+  }
+
+  const stepCopy = STEP_TITLES[currentStep]
 
   return (
-    <>
-      <div className="max-w-3xl mx-auto px-4 pt-3 pb-4 sm:py-[60px] flex flex-col items-center gap-4 sm:gap-8">
+    <div className="max-w-3xl mx-auto px-4 pt-3 pb-4 sm:py-[60px] flex flex-col items-center gap-4 sm:gap-8">
 
-        {/* Badge */}
-        <div className="inline-flex items-center gap-1.5 bg-[#aedee5] rounded-full px-4 py-2 sm:py-2.5 shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]">
-          <span className="font-serif-body font-bold text-[#002042] text-base sm:text-xl leading-none tracking-[-0.8px]">
-            Question {currentStep + 1}/{steps.length}
-          </span>
-          <Smile className="w-5 h-5 sm:w-6 sm:h-6 text-[#002042]" />
-        </div>
-
-        {/* Progress bar */}
-        <div className="w-full bg-[#eef5fc] rounded-[100px] h-3 sm:h-4 relative overflow-hidden">
-          <div
-            className="absolute inset-y-0 left-0 rounded-[100px] transition-[width] duration-500"
-            style={{
-              width: `${getProgress()}%`,
-              background: "linear-gradient(7.67deg, #aedee5 0%, #b9e15c 99.27%)",
-            }}
-          />
-        </div>
-
-        {/* Card */}
-        <div className="bg-white rounded-[20px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] w-full flex flex-col gap-4 sm:gap-6 p-4 sm:p-8">
-
-          {/* Title + description */}
-          <div className="flex flex-col gap-1.5 sm:gap-3">
-            <h2 className="font-heading font-bold text-[20px] sm:text-[24px] text-[#002042] tracking-[-0.72px] leading-[1.2]">
-              {steps[currentStep].title}
-            </h2>
-            <p className="font-serif-body text-[14px] sm:text-[18px] text-[#002042] tracking-[-0.04em] leading-[1.2]">
-              {steps[currentStep].description}
-            </p>
-          </div>
-
-          {/* Options */}
-          <div className="flex flex-col gap-2 sm:gap-4">
-
-            {/* Step 0: Système de chauffage */}
-            {currentStep === 0 && [
-              { value: "electricite", label: "Électricité (plinthes, air pulsé, thermopompe)" },
-              { value: "bi-energie", label: "Bi-énergie (Hydro + combustible)" },
-              { value: "gaz", label: "Gaz naturel" },
-              { value: "mazout", label: "Mazout" },
-              { value: "eau-chaude", label: "Système à eau chaude (chaudière/radiateurs)" },
-              { value: "autre", label: "Autre / Je ne sais pas" },
-            ].map((option) => {
-              const selected = answers.heatingSystem === option.value
-              return (
-                <div
-                  key={option.value}
-                  onClick={() => selectAndAdvance('heatingSystem', option.value)}
-                  className={`flex items-center gap-3 sm:gap-4 p-3 sm:p-4 rounded-[20px] cursor-pointer transition-all ${
-                    selected ? "bg-[#ecf8cf] border-2 border-[#86a735]" : "bg-white border border-[#aedee5] hover:border-[#375371]"
-                  }`}
-                >
-                  {selected ? (
-                    <div className="flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded-full bg-[#86a735] flex items-center justify-center">
-                      <Check className="w-3 h-3 sm:w-3.5 sm:h-3.5 text-white stroke-[3]" />
-                    </div>
-                  ) : (
-                    <div className="flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded-full border-2 border-[#aedee5]" />
-                  )}
-                  <span className="font-serif-body font-semibold text-sm sm:text-[20px] text-[#002042] tracking-[-0.05em] leading-[1.2]">
-                    {option.label}
-                  </span>
-                </div>
-              )
-            })}
-
-            {/* Step 1: État de l'isolation */}
-            {currentStep === 1 && [
-              { value: "aucune", label: "Aucune isolation ou très peu" },
-              { value: "partielle", label: "Isolation partielle" },
-              { value: "complete", label: "Isolation complète mais ancienne" },
-              { value: "recente", label: "Isolation récente" },
-              { value: "inconnue", label: "Je ne sais pas" },
-            ].map((option) => {
-              const selected = answers.currentInsulation === option.value
-              return (
-                <div
-                  key={option.value}
-                  onClick={() => selectAndAdvance('currentInsulation', option.value)}
-                  className={`flex items-center gap-3 sm:gap-4 p-3 sm:p-4 rounded-[20px] cursor-pointer transition-all ${
-                    selected ? "bg-[#ecf8cf] border-2 border-[#86a735]" : "bg-white border border-[#aedee5] hover:border-[#375371]"
-                  }`}
-                >
-                  {selected ? (
-                    <div className="flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded-full bg-[#86a735] flex items-center justify-center">
-                      <Check className="w-3 h-3 sm:w-3.5 sm:h-3.5 text-white stroke-[3]" />
-                    </div>
-                  ) : (
-                    <div className="flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded-full border-2 border-[#aedee5]" />
-                  )}
-                  <span className="font-serif-body font-semibold text-sm sm:text-[20px] text-[#002042] tracking-[-0.05em] leading-[1.2]">
-                    {option.label}
-                  </span>
-                </div>
-              )
-            })}
-
-            {/* Step 2: Accès à l'entre-toit */}
-            {currentStep === 2 && [
-              { value: "facile", label: "Accès facile depuis l'intérieur" },
-              { value: "trappe", label: "Trappe d'accès disponible" },
-              { value: "difficile", label: "Accès difficile ou limité" },
-              { value: "aucun", label: "Aucun accès direct" },
-              { value: "inconnue", label: "Je ne sais pas" },
-            ].map((option) => {
-              const selected = answers.atticAccess === option.value
-              return (
-                <div
-                  key={option.value}
-                  onClick={() => selectAndAdvance('atticAccess', option.value)}
-                  className={`flex items-center gap-3 sm:gap-4 p-3 sm:p-4 rounded-[20px] cursor-pointer transition-all ${
-                    selected ? "bg-[#ecf8cf] border-2 border-[#86a735]" : "bg-white border border-[#aedee5] hover:border-[#375371]"
-                  }`}
-                >
-                  {selected ? (
-                    <div className="flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded-full bg-[#86a735] flex items-center justify-center">
-                      <Check className="w-3 h-3 sm:w-3.5 sm:h-3.5 text-white stroke-[3]" />
-                    </div>
-                  ) : (
-                    <div className="flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded-full border-2 border-[#aedee5]" />
-                  )}
-                  <span className="font-serif-body font-semibold text-sm sm:text-[20px] text-[#002042] tracking-[-0.05em] leading-[1.2]">
-                    {option.label}
-                  </span>
-                </div>
-              )
-            })}
-
-            {/* Step 3: Problèmes identifiés (multi-select) */}
-            {currentStep === 3 && [
-              { value: "moisissure", label: "Moisissure ou humidité" },
-              { value: "courants-air", label: "Courants d'air" },
-              { value: "factures-elevees", label: "Factures d'énergie élevées" },
-              { value: "temperature-inegale", label: "Température inégale entre les pièces" },
-              { value: "glace", label: "Formation de glace sur le toit" },
-              { value: "aucun", label: "Aucun problème identifié" },
-            ].map((problem) => {
-              const checked = answers.identifiedProblems.includes(problem.value)
-              return (
-                <div
-                  key={problem.value}
-                  onClick={() => handleProblemToggle(problem.value)}
-                  className={`flex items-center gap-3 sm:gap-4 p-3 sm:p-4 rounded-[20px] cursor-pointer transition-all ${
-                    checked ? "bg-[#ecf8cf] border-2 border-[#86a735]" : "bg-white border border-[#aedee5] hover:border-[#375371]"
-                  }`}
-                >
-                  {checked ? (
-                    <div className="flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded-[6px] bg-[#86a735] flex items-center justify-center">
-                      <Check className="w-3 h-3 sm:w-3.5 sm:h-3.5 text-white stroke-[3]" />
-                    </div>
-                  ) : (
-                    <div className="flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded-[6px] border-2 border-[#aedee5]" />
-                  )}
-                  <span className="font-serif-body font-semibold text-sm sm:text-[20px] text-[#002042] tracking-[-0.05em] leading-[1.2]">
-                    {problem.label}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
-
-          {/* Navigation */}
-          <div className="flex justify-between items-center pt-2 sm:pt-0 border-t border-[#e8e8e0]">
-            <button
-              onClick={handlePrevious}
-              disabled={currentStep === 0}
-              className="flex items-center gap-2 font-serif-body font-bold text-[#375371] hover:text-[#002042] disabled:opacity-30 disabled:cursor-not-allowed transition-colors px-1 py-2 sm:py-3 text-sm sm:text-[18px]"
-            >
-              <ArrowLeft className="w-4 h-4 sm:w-5 sm:h-5" />
-              Précédent
-            </button>
-
-            {currentStep === steps.length - 1 ? (
-              <button
-                onClick={handleNext}
-                disabled={!canGoNext()}
-                className="flex items-center gap-1.5 bg-[#b9e15c] border-2 border-[#002042] text-[#002042] font-heading font-bold py-2 px-4 sm:py-3 sm:px-8 rounded-full shadow-[-2px_4px_0_0_#002042] hover:shadow-[-1px_2px_0_0_#002042] hover:translate-y-0.5 transition-all disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none disabled:translate-y-0 text-sm sm:text-[18px]"
-              >
-                Obtenir ma soumission
-                <CheckCircle className="w-4 h-4" />
-              </button>
-            ) : (
-              <div className="w-[90px] sm:w-[120px]" />
-            )}
-          </div>
-        </div>
+      {/* Badge */}
+      <div className="inline-flex items-center gap-1.5 bg-[#aedee5] rounded-full px-4 py-2 sm:py-2.5 shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]">
+        <span className="font-serif-body font-bold text-[#002042] text-base sm:text-xl leading-none tracking-[-0.8px]">
+          Question {currentStep + 1}/{totalSteps}
+        </span>
+        <Smile className="w-5 h-5 sm:w-6 sm:h-6 text-[#002042]" />
       </div>
 
-      {/* Lead Capture Popup */}
-      {showLeadCapture && (
-        <LeadCapturePopup
-          isOpen={showLeadCapture}
-          onClose={() => setShowLeadCapture(false)}
-          onSubmit={handleLeadSubmit}
-          isSubmitting={isSubmittingLead}
-          roofData={roofData}
+      {/* Progress bar */}
+      <div className="w-full bg-[#eef5fc] rounded-[100px] h-3 sm:h-4 relative overflow-hidden">
+        <div
+          className="absolute inset-y-0 left-0 rounded-[100px] transition-[width] duration-500"
+          style={{
+            width: `${getProgress()}%`,
+            background: "linear-gradient(7.67deg, #aedee5 0%, #b9e15c 99.27%)",
+          }}
         />
-      )}
-    </>
+      </div>
+
+      {/* Card */}
+      <div className="bg-white rounded-[20px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)] w-full flex flex-col gap-4 sm:gap-6 p-4 sm:p-8">
+
+        {/* Title + description */}
+        <div className="flex flex-col gap-1.5 sm:gap-3">
+          <h2 className="font-heading font-bold text-[20px] sm:text-[24px] text-[#002042] tracking-[-0.72px] leading-[1.2]">
+            {stepCopy.title}
+          </h2>
+          <p className="font-serif-body text-[14px] sm:text-[18px] text-[#002042] tracking-[-0.04em] leading-[1.2]">
+            {stepCopy.description}
+          </p>
+        </div>
+
+        {/* Options */}
+        <div className="flex flex-col gap-2 sm:gap-4">
+
+          {/* Q1 — Symptômes (multi-select) */}
+          {currentStep === 0 && SYMPTOMS_OPTIONS.map((option) => {
+            const checked = answers.symptoms.includes(option.code)
+            return (
+              <div
+                key={option.code}
+                onClick={() => handleSymptomToggle(option.code)}
+                className={`flex items-center gap-3 sm:gap-4 p-3 sm:p-4 rounded-[20px] cursor-pointer transition-all ${
+                  checked ? "bg-[#ecf8cf] border-2 border-[#86a735]" : "bg-white border border-[#aedee5] hover:border-[#375371]"
+                }`}
+              >
+                {checked ? (
+                  <div className="flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded-[6px] bg-[#86a735] flex items-center justify-center">
+                    <Check className="w-3 h-3 sm:w-3.5 sm:h-3.5 text-white stroke-[3]" />
+                  </div>
+                ) : (
+                  <div className="flex-shrink-0 w-5 h-5 sm:w-6 sm:h-6 rounded-[6px] border-2 border-[#aedee5]" />
+                )}
+                <span className="text-xl sm:text-2xl" aria-hidden>{option.emoji}</span>
+                <span className="font-serif-body font-semibold text-sm sm:text-[20px] text-[#002042] tracking-[-0.05em] leading-[1.2]">
+                  {option.label}
+                </span>
+              </div>
+            )
+          })}
+
+          {/* Q2 — Facture Hydro (4 brackets, auto-advance) */}
+          {currentStep === 1 && HYDRO_BRACKETS.map((bracket) => {
+            const selected = answers.hydroBracket === bracket.code
+            return (
+              <div
+                key={bracket.code}
+                onClick={() => handleHydroSelect(bracket.code)}
+                className={`flex items-center gap-3 sm:gap-4 p-3 sm:p-4 rounded-[20px] cursor-pointer transition-all border-2 ${
+                  selected ? bracket.selected : `${bracket.base} hover:brightness-95`
+                }`}
+              >
+                <span className="text-2xl sm:text-3xl" aria-hidden>{bracket.emoji}</span>
+                <span className="font-serif-body font-semibold text-sm sm:text-[20px] text-[#002042] tracking-[-0.05em] leading-[1.2]">
+                  {bracket.label}
+                </span>
+              </div>
+            )
+          })}
+
+          {/* Q3 — Intent (auto-advance) */}
+          {currentStep === 2 && INTENT_OPTIONS.map((option) => {
+            const selected = answers.intent === option.code
+            return (
+              <div
+                key={option.code}
+                onClick={() => handleIntentSelect(option.code)}
+                className={`flex flex-col items-start gap-2 sm:gap-3 p-4 sm:p-6 rounded-[20px] cursor-pointer transition-all ${
+                  selected ? "bg-[#ecf8cf] border-2 border-[#86a735]" : "bg-white border border-[#aedee5] hover:border-[#375371]"
+                }`}
+              >
+                <div className="flex items-center gap-3 sm:gap-4">
+                  <span className="text-2xl sm:text-3xl" aria-hidden>{option.emoji}</span>
+                  <span className="font-heading font-bold text-base sm:text-[22px] text-[#002042] tracking-[-0.04em] leading-[1.2]">
+                    {option.label}
+                  </span>
+                </div>
+                <span className="font-serif-body italic text-xs sm:text-[16px] text-[#375371] tracking-[-0.03em] leading-[1.2] pl-9 sm:pl-12">
+                  {option.sub}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Navigation */}
+        <div className="flex justify-between items-center pt-2 sm:pt-0 border-t border-[#e8e8e0]">
+          <button
+            onClick={handlePrevious}
+            disabled={currentStep === 0 || isAdvancing}
+            className="flex items-center gap-2 font-serif-body font-bold text-[#375371] hover:text-[#002042] disabled:opacity-30 disabled:cursor-not-allowed transition-colors px-1 py-2 sm:py-3 text-sm sm:text-[18px]"
+          >
+            <ArrowLeft className="w-4 h-4 sm:w-5 sm:h-5" />
+            Précédent
+          </button>
+
+          {currentStep === 0 ? (
+            <button
+              onClick={handleSymptomNext}
+              disabled={answers.symptoms.length === 0 || isAdvancing}
+              className="flex items-center gap-1.5 bg-[#b9e15c] border-2 border-[#002042] text-[#002042] font-heading font-bold py-2 px-4 sm:py-3 sm:px-8 rounded-full shadow-[-2px_4px_0_0_#002042] hover:shadow-[-1px_2px_0_0_#002042] hover:translate-y-0.5 transition-all disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none disabled:translate-y-0 text-sm sm:text-[18px]"
+            >
+              {answers.symptoms.length === 0 ? 'Sélectionne au moins un' : 'Suivant'}
+              <CheckCircle className="w-4 h-4" />
+            </button>
+          ) : (
+            <div className="w-[90px] sm:w-[120px]" />
+          )}
+        </div>
+      </div>
+    </div>
   )
 }

--- a/lib/funnel-config.ts
+++ b/lib/funnel-config.ts
@@ -1,0 +1,61 @@
+// V2 funnel configuration — symptoms, hydro brackets, intent
+// Used by /analysis wizard V2 + lead-capture-form for V2 → V1 mapping.
+
+export const SYMPTOMS_OPTIONS = [
+  { code: 'hydro_up',      label: "Ma facture d'Hydro monte chaque année",     emoji: '⚡' },
+  { code: 'cold_winter',   label: "Ma maison est froide en hiver",              emoji: '🥶' },
+  { code: 'hot_summer',    label: "C'est étouffant l'été, surtout en haut",     emoji: '🥵' },
+  { code: 'ice_roof',      label: "J'ai de la glace ou des glaçons sur le toit", emoji: '🧊' },
+  { code: 'drafts',        label: "Je sens des courants d'air",                 emoji: '💨' },
+  { code: 'uneven_temp',   label: "Un étage est chaud, l'autre est froid",      emoji: '🌡️' },
+  { code: 'humidity_mold', label: "J'ai de l'humidité ou de la moisissure",     emoji: '💧' },
+] as const
+
+export type SymptomCode = typeof SYMPTOMS_OPTIONS[number]['code']
+
+export const HYDRO_BRACKETS = [
+  { code: 'lt_125',  label: 'Moins de 125 $ / mois',       emoji: '💰',
+    base:     'border-green-700 bg-green-100',
+    selected: 'border-green-800 bg-green-200 ring-2 ring-inset ring-green-800' },
+  { code: '125_200', label: 'Entre 125 $ et 200 $ / mois', emoji: '💰💰',
+    base:     'border-yellow-700 bg-yellow-100',
+    selected: 'border-yellow-800 bg-yellow-200 ring-2 ring-inset ring-yellow-800' },
+  { code: '200_300', label: 'Entre 200 $ et 300 $ / mois', emoji: '💰💰💰',
+    base:     'border-orange-700 bg-orange-100',
+    selected: 'border-orange-800 bg-orange-200 ring-2 ring-inset ring-orange-800' },
+  { code: 'gt_300',  label: 'Plus de 300 $ / mois',        emoji: '🔥',
+    base:     'border-red-700 bg-red-100',
+    selected: 'border-red-800 bg-red-200 ring-2 ring-inset ring-red-800' },
+] as const
+
+export type HydroBracketCode = typeof HYDRO_BRACKETS[number]['code']
+
+export const INTENT_OPTIONS = [
+  { code: 'qualified', label: 'Je veux faire les travaux',     sub: 'Je suis prêt à recevoir un inspecteur qualifié', emoji: '🔨' },
+  { code: 'curious',   label: 'Je suis juste curieux du coût', sub: 'Juste pour savoir, pas pressé',                  emoji: '💭' },
+] as const
+
+export type IntentCode = typeof INTENT_OPTIONS[number]['code']
+
+export interface V2Answers {
+  symptoms: SymptomCode[]
+  hydroBracket: HydroBracketCode | ''
+  intent: IntentCode | ''
+}
+
+// Map V2 symptoms (new codes) to V1 identifiedProblems (legacy codes used by
+// calculateInsulationPricing and GHL/Make payload). Defaults to ['aucun'] when
+// nothing maps so legacy consumers don't choke on empty arrays.
+export function mapV2SymptomsToV1(v2Symptoms: readonly string[]): string[] {
+  const map: Record<string, string> = {
+    humidity_mold: 'moisissure',
+    drafts: 'courants-air',
+    hydro_up: 'factures-elevees',
+    uneven_temp: 'temperature-inegale',
+    ice_roof: 'glace',
+    cold_winter: 'temperature-inegale',
+    hot_summer: 'temperature-inegale',
+  }
+  const v1 = v2Symptoms.map((s) => map[s]).filter(Boolean)
+  return v1.length ? Array.from(new Set(v1)) : ['aucun']
+}

--- a/lib/funnel-config.ts
+++ b/lib/funnel-config.ts
@@ -59,3 +59,23 @@ export function mapV2SymptomsToV1(v2Symptoms: readonly string[]): string[] {
   const v1 = v2Symptoms.map((s) => map[s]).filter(Boolean)
   return v1.length ? Array.from(new Set(v1)) : ['aucun']
 }
+
+// V1-shaped answers built from V2 answers + conservative defaults. Used both by
+// LeadCaptureForm (to compute pricingData submitted to /api/leads) and by
+// /analysis state="pricing" (to render InsulationResults with the same inputs
+// so the displayed estimate matches the one stored in GHL).
+export interface V1AnswersForPricing {
+  heatingSystem: string
+  currentInsulation: string
+  atticAccess: string
+  identifiedProblems: string[]
+}
+
+export function buildV1AnswersFromV2(v2: V2Answers): V1AnswersForPricing {
+  return {
+    heatingSystem: 'electricite',
+    currentInsulation: 'partielle',
+    atticAccess: 'facile',
+    identifiedProblems: mapV2SymptomsToV1(v2.symptoms),
+  }
+}

--- a/lib/ghl-client.ts
+++ b/lib/ghl-client.ts
@@ -51,6 +51,12 @@ export interface NormalizedLead {
   internalLeadId?: string
   // Optional notes appended on creation
   noteBody?: string
+  // Phase 2 V2: replaces VERTICAL_TAG[vertical] on the contact when set
+  // (e.g. 'Lead Iso Hot' / 'Lead Iso Curieux' for the /analysis funnel).
+  tagOverride?: string
+  // Phase 2 V2: tags to remove after upsert (best-effort). Used for the
+  // curious→qualified override (drop 'Lead Iso Curieux' once hot).
+  tagsToRemove?: string[]
 }
 
 interface GHLContactPayload {
@@ -151,7 +157,13 @@ function buildContactPayload(
     postalCode: lead.postalCode,
     country: 'CA',
     source: lead.leadSource ?? lead.utmSource ?? 'vercel-direct',
-    tags: [VERTICAL_TAG[lead.vertical]],
+    // When a tagOverride is set (isolation V2 Hot/Curieux), DON'T put tags in
+    // the upsert: GHL's upsert REPLACES the whole tags array, which would wipe
+    // an existing 'Lead Iso Hot' on a qualified→curious re-submit (violates
+    // décision 8: once Hot, stays Hot). Instead postLeadToGHL adds the tag via
+    // POST /tags (idempotent, non-destructive). Other verticals keep the
+    // upsert tag (no Hot/Curieux state transitions → no overwrite risk).
+    ...(lead.tagOverride ? {} : { tags: [VERTICAL_TAG[lead.vertical]] }),
     customFields,
   }
 }
@@ -265,6 +277,44 @@ export async function postLeadToGHL(lead: NormalizedLead): Promise<GHLPostResult
       method: 'POST',
       body: JSON.stringify({ body: lead.noteBody }),
     })
+  }
+
+  // Phase 2 V2: isolation Hot/Curieux tag, added via POST /tags (NOT the upsert).
+  // POST /tags is additive + idempotent: it never wipes other tags, so a
+  // qualified→curious re-submit ADDS 'Lead Iso Curieux' while KEEPING any
+  // existing 'Lead Iso Hot' (décision 8: once Hot, stays Hot). The upsert tag
+  // was suppressed in buildContactPayload when tagOverride is set.
+  if (contactId && lead.tagOverride) {
+    const addRes = await ghlRequest(apiKey, `/contacts/${contactId}/tags`, {
+      method: 'POST',
+      body: JSON.stringify({ tags: [lead.tagOverride] }),
+    })
+    if (!addRes.ok) {
+      console.warn(`[ghl-client] tag add failed for ${contactId}:`, addRes.error)
+    }
+  }
+
+  // Phase 2 V2: remove stale tags after upsert (best-effort). Used for the
+  // curious→qualified override — a 'Lead Iso Curieux' contact re-submitting as
+  // qualified gets 'Lead Iso Hot' added above and 'Lead Iso Curieux' dropped
+  // here, so the contact carries a single source of truth. (One-way only:
+  // qualified→curious sets no tagsToRemove, preserving Hot per décision 8.)
+  //
+  // We never block / fail the lead on a tag-removal error — the contact + its
+  // hot tag are already persisted; a leftover curious tag is cosmetic.
+  //
+  // Endpoint: DELETE /contacts/{contactId}/tags. Body `{ tags: [...] }` is
+  // inferred from the ADD endpoint (the Remove docs don't spell out the body).
+  // Validate with a curl on a test contact in preview before prod; if the
+  // schema differs (e.g. query param), adjust here.
+  if (contactId && lead.tagsToRemove && lead.tagsToRemove.length > 0) {
+    const removeRes = await ghlRequest(apiKey, `/contacts/${contactId}/tags`, {
+      method: 'DELETE',
+      body: JSON.stringify({ tags: lead.tagsToRemove }),
+    })
+    if (!removeRes.ok) {
+      console.warn(`[ghl-client] tag removal failed for ${contactId}:`, removeRes.error)
+    }
   }
 
   return { contactId, duplicate, contactStatus: created.status }

--- a/lib/ghl-client.ts
+++ b/lib/ghl-client.ts
@@ -279,15 +279,21 @@ export async function postLeadToGHL(lead: NormalizedLead): Promise<GHLPostResult
     })
   }
 
-  // Phase 2 V2: isolation Hot/Curieux tag, added via POST /tags (NOT the upsert).
+  // Phase 2 V2: isolation tags added via POST /tags (NOT the upsert).
   // POST /tags is additive + idempotent: it never wipes other tags, so a
   // qualified→curious re-submit ADDS 'Lead Iso Curieux' while KEEPING any
   // existing 'Lead Iso Hot' (décision 8: once Hot, stays Hot). The upsert tag
   // was suppressed in buildContactPayload when tagOverride is set.
+  //
+  // We add BOTH the base vertical tag ('Lead Iso') AND the Hot/Curieux
+  // override: V1 leads + every other vertical keep 'Lead Iso' via the upsert,
+  // so V2 leads must too — otherwise existing GHL workflows/smartlists filtering
+  // on 'Lead Iso' would silently stop matching V2 leads. POST is idempotent so
+  // re-adding 'Lead Iso' on a duplicate is a no-op.
   if (contactId && lead.tagOverride) {
     const addRes = await ghlRequest(apiKey, `/contacts/${contactId}/tags`, {
       method: 'POST',
-      body: JSON.stringify({ tags: [lead.tagOverride] }),
+      body: JSON.stringify({ tags: [VERTICAL_TAG[lead.vertical], lead.tagOverride] }),
     })
     if (!addRes.ok) {
       console.warn(`[ghl-client] tag add failed for ${contactId}:`, addRes.error)

--- a/lib/ghl-fields-iso.ts
+++ b/lib/ghl-fields-iso.ts
@@ -37,4 +37,8 @@ export const GHL_FIELDS_ISO: Record<string, GHLFieldDef> = {
   type_habitation: { id: 'gYP4OaxndoaSXgc1aN3Q', name: 'Type habitation', key: 'type_habitation', type: 'TEXT' },
   statut_proprietaire: { id: 'UNu3xqfPmSU5jlUA4sLp', name: 'Statut proprietaire', key: 'statut_proprietaire', type: 'TEXT' },
   eligible_subvention: { id: 'Y17HfEbVj0i4kzN4JPoz', name: 'Eligible subvention', key: 'eligible_subvention', type: 'TEXT' },
+  // V2 funnel fields (Phase 2 will wire these into the payload).
+  symptoms: { id: 'ZPE3HqwuNU2UFMPJoFLP', name: 'Symptoms', key: 'symptoms', type: 'TEXT' },
+  hydro_bracket: { id: '09Yv7GFbSI63gpw2dnMS', name: 'Hydro Bracket', key: 'hydro_bracket', type: 'TEXT' },
+  intent: { id: 'TXLCBATiEunuBmhBfiPk', name: 'Intent', key: 'intent', type: 'TEXT' },
 } as const

--- a/lib/meta-config.ts
+++ b/lib/meta-config.ts
@@ -28,3 +28,26 @@ export function initializeMeta() {
 export function isMetaConfigured(): boolean {
   return !!(META_CONFIG.PIXEL_ID && META_CONFIG.ACCESS_TOKEN);
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// Dedicated soumissionconfort pixel — funnel /analysis only (Phase 2 V2).
+// Separate Meta Business Manager pixel, cohabits with META_CONFIG (the Niku
+// shared pixel that keeps serving homepage/thermopompes/subventions/rapide).
+// ───────────────────────────────────────────────────────────────────────────
+export const META_CONFIG_SOUMISSIONCONFORT = {
+  PIXEL_ID: process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT || '',
+  ACCESS_TOKEN: process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT || '',
+  TEST_EVENT_CODE: process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT || undefined,
+};
+
+// True only when both id + token are real (not empty, not the XXXXXX
+// placeholder). Lets the CAPI routes skip silently during the rollout window
+// before the pixel exists, instead of POSTing garbage to Meta.
+export function isSoumissionConfortMetaConfigured(): boolean {
+  const id = META_CONFIG_SOUMISSIONCONFORT.PIXEL_ID;
+  const token = META_CONFIG_SOUMISSIONCONFORT.ACCESS_TOKEN;
+  if (!id || !token) return false;
+  // Guard against the XXXXXX placeholder Zack writes before the pixel exists.
+  if (/^X+$/i.test(id) || /^X+$/i.test(token)) return false;
+  return true;
+}

--- a/lib/meta-conversion-api.ts
+++ b/lib/meta-conversion-api.ts
@@ -98,21 +98,38 @@ export class MetaConversionAPI {
     this.testEventCode = testEventCode;
   }
 
-  // Track ViewContent event (when user enters website)
-  async trackViewContent(contentName?: string, contentType?: string) {
+  // Track ViewContent event. Accepts an object so the /analysis wizard can pass
+  // an eventId for browser↔CAPI dedup, plus server-side client info (ip/ua/url)
+  // that getClientInfo() can't supply outside the browser.
+  async trackViewContent(data: {
+    contentName?: string
+    contentType?: string
+    searchString?: string
+    eventId?: string
+    clientIp?: string
+    userAgent?: string
+    sourceUrl?: string
+  } = {}) {
+    // Prefer explicit server-passed client info; fall back to browser cookies
+    // (_fbp/_fbc) + UA when called client-side.
+    const userData: NonNullable<MetaConversionEvent['user_data']> = { ...getClientInfo() };
+    if (data.clientIp) userData.client_ip_address = data.clientIp;
+    if (data.userAgent) userData.client_user_agent = data.userAgent;
+
     const event: MetaConversionEvent = {
       event_name: 'ViewContent',
+      event_id: data.eventId,
       event_time: Math.floor(Date.now() / 1000),
       action_source: 'website',
-      user_data: {
-        ...getClientInfo()
-      },
+      user_data: userData,
       custom_data: {
-        content_type: contentType || 'website',
-        content_name: contentName || 'Homepage',
-        currency: 'CAD'
+        content_type: data.contentType || 'website',
+        content_name: data.contentName || 'Homepage',
+        currency: 'CAD',
+        ...(data.searchString ? { search_string: data.searchString } : {}),
       },
-      event_source_url: typeof window !== 'undefined' ? window.location.href : undefined
+      event_source_url: data.sourceUrl
+        || (typeof window !== 'undefined' ? window.location.href : undefined),
     };
 
     return this.sendEvent(event);
@@ -340,9 +357,17 @@ export function getMetaConversionAPI(): MetaConversionAPI | null {
 }
 
 // Convenience functions for tracking events
-export async function trackViewContent(contentName?: string, contentType?: string) {
+export async function trackViewContent(data: {
+  contentName?: string
+  contentType?: string
+  searchString?: string
+  eventId?: string
+  clientIp?: string
+  userAgent?: string
+  sourceUrl?: string
+} = {}) {
   if (metaAPI) {
-    return await metaAPI.trackViewContent(contentName, contentType);
+    return await metaAPI.trackViewContent(data);
   }
   console.warn('Meta Conversion API not initialized');
   return { success: false, error: 'API not initialized' };

--- a/scripts/setup-ghl-iso-funnel-v2-fields.mjs
+++ b/scripts/setup-ghl-iso-funnel-v2-fields.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// One-off script: creates the 3 V2 funnel custom fields in the Iso GHL sub-account.
+// Run: node --env-file=.env.local scripts/setup-ghl-iso-funnel-v2-fields.mjs
+//
+// After it runs, copy the printed IDs into lib/ghl-fields-iso.ts (manual edit).
+// The fields:
+//   - symptoms      → V2 symptoms multi-select stored as CSV (TEXT)
+//   - hydro_bracket → V2 hydro bracket single value (TEXT)
+//   - intent        → V2 intent single value 'qualified' | 'curious' (TEXT)
+
+const API_BASE = 'https://services.leadconnectorhq.com'
+const VERSION = '2021-07-28'
+
+const apiKey = process.env.GHL_API_KEY_ISO
+const locationId = process.env.GHL_LOCATION_ID_ISO
+
+if (!apiKey || !locationId) {
+  console.error('❌ GHL_API_KEY_ISO and GHL_LOCATION_ID_ISO must be set in .env.local')
+  process.exit(1)
+}
+
+const FIELDS_TO_CREATE = [
+  {
+    name: 'Symptoms',
+    fieldKey: 'symptoms',
+    dataType: 'TEXT',
+    placeholder: 'hydro_up,drafts,humidity_mold',
+  },
+  {
+    name: 'Hydro Bracket',
+    fieldKey: 'hydro_bracket',
+    dataType: 'TEXT',
+    placeholder: 'lt_125 | 125_200 | 200_300 | gt_300',
+  },
+  {
+    name: 'Intent',
+    fieldKey: 'intent',
+    dataType: 'TEXT',
+    placeholder: 'qualified | curious',
+  },
+]
+
+async function listExistingFields() {
+  const res = await fetch(`${API_BASE}/locations/${locationId}/customFields`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Version: VERSION,
+    },
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`List failed: ${res.status} ${text}`)
+  }
+  const body = await res.json()
+  return body.customFields || body.data || []
+}
+
+async function createField({ name, fieldKey, dataType, placeholder }) {
+  const payload = {
+    name,
+    dataType,
+    placeholder,
+    model: 'contact',
+  }
+  const res = await fetch(`${API_BASE}/locations/${locationId}/customFields/`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      Version: VERSION,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+  const text = await res.text()
+  if (!res.ok) {
+    throw new Error(`Create "${name}" failed: ${res.status} ${text}`)
+  }
+  return JSON.parse(text)
+}
+
+async function main() {
+  console.log(`📍 Sub-account: ${locationId}`)
+  console.log(`🔍 Listing existing custom fields…`)
+  const existing = await listExistingFields()
+  console.log(`   Found ${existing.length} existing fields.`)
+
+  const created = {}
+  for (const def of FIELDS_TO_CREATE) {
+    // Match by name or fieldKey to avoid duplicates.
+    const dup = existing.find(
+      (f) =>
+        f.name?.toLowerCase() === def.name.toLowerCase() ||
+        f.fieldKey?.toLowerCase() === def.fieldKey.toLowerCase() ||
+        f.fieldKey?.toLowerCase() === `contact.${def.fieldKey.toLowerCase()}`,
+    )
+    if (dup) {
+      console.log(`⏭  Skipping "${def.name}" — already exists (id ${dup.id})`)
+      created[def.fieldKey] = { id: dup.id, name: dup.name, fieldKey: dup.fieldKey, type: dup.dataType }
+      continue
+    }
+    console.log(`➕ Creating "${def.name}"…`)
+    const resp = await createField(def)
+    const field = resp.customField || resp.field || resp
+    created[def.fieldKey] = {
+      id: field.id,
+      name: field.name,
+      fieldKey: field.fieldKey || def.fieldKey,
+      type: field.dataType || def.dataType,
+    }
+    console.log(`   ✅ Created. id=${field.id}`)
+  }
+
+  console.log('')
+  console.log('====================================================================')
+  console.log('Paste this into lib/ghl-fields-iso.ts inside GHL_FIELDS_ISO map:')
+  console.log('====================================================================')
+  for (const [key, f] of Object.entries(created)) {
+    console.log(`  ${key}: { id: '${f.id}', name: '${f.name}', key: '${key}', type: '${f.type}' },`)
+  }
+}
+
+main().catch((err) => {
+  console.error('❌', err.message || err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- Refactor `/analysis` wizard from 4 V1 questions to 3 V2 questions (symptoms / hydroBracket / intent). Lead capture moves from in-wizard popup to a full-page form styled like the existing `LeadCapturePopup` (cyan savings highlight, popup copy/CTA).
- `/api/leads` payload stays backward-compatible: V1 defaults + V2 passthrough (`symptoms`, `hydro_bracket`, `intent`). No backend code changes — Phase 2 will wire the V2 fields into GHL/Make.
- Infra prep for Phase 2: 3 new GHL custom fields created in the Iso sub-account via `scripts/setup-ghl-iso-funnel-v2-fields.mjs` and mapped in `lib/ghl-fields-iso.ts`. Not yet consumed by the lead pipeline.

## Test plan
- [ ] Vercel preview: homepage CTA → autocomplete adresse → `/analysis?address=...`
- [ ] Q1 (symptoms multi): bouton "Suivant" disabled tant qu'aucune coche; auto-advance non.
- [ ] Q2 (hydro): 4 brackets vert/jaune/orange/rouge bien visibles; auto-advance OK.
- [ ] Q3 (intent): auto-advance OK; route vers lead form.
- [ ] Lead form: bandeau cyan avec économies estimées, CTA lime "Découvrir mon estimation maintenant", loading state in-button.
- [ ] Submit lead OTP off → `/api/leads` POST succeeds; payload contains V1 defaults + V2 passthrough.
- [ ] Submit lead OTP on → redirect `/verifier-telephone` → après OTP → `/pricing?leadId=…&d=…` affiche InsulationResults.
- [ ] `/pricing` final page: bandeau "Prêt à économiser…" en bas est retiré; CTA card navy en haut toujours présente.
- [ ] Régression: `/thermopompes` continue d'utiliser `LeadCapturePopup`.
- [ ] Vérif GHL UI: 3 nouveaux fields `Symptoms`, `Hydro Bracket`, `Intent` visibles dans le sub-account Iso.

## Followup — Phase 2 backend (séparée)
- Meta Pixel dédié `soumissionconfort` (env vars, gating qualifié/curieux après OTP).
- GHL routing par tag (`Lead Iso Hot` / `Lead Iso Curieux`) — stage "new lead hot" à créer manuellement.
- Wire `symptoms` / `hydro_bracket` / `intent` dans `lib/ghl-client.ts` mapping + Make scenario column mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)