### PR TITLE
feat(analysis): Phase 2 funnel V2 backend — dedicated pixel + GHL V2 fields + dynamic tags

### DIFF
--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -29,6 +29,19 @@ NEXT_PUBLIC_META_PIXEL_ID=votre_pixel_id
 META_CONVERSION_API_TOKEN=votre_token_conversion_api
 META_PIXEL_ID=votre_pixel_id
 
+# ----------------------------------------------------------------------------
+# Pixel dédié soumissionconfort — funnel /analysis V2 (Phase 2)
+# ----------------------------------------------------------------------------
+# Utilisé UNIQUEMENT par le funnel /analysis (+ /verifier-telephone). Les autres
+# funnels (/thermopompes, /subventions, /soumission-rapide) restent sur
+# NEXT_PUBLIC_META_PIXEL_ID. Pixel créé dans le Business Manager soumissionconfort,
+# séparé du pixel Niku → audience isolation 100% clean.
+# Placeholder XXXXXX = skip strict (aucun pixel browser, aucun CAPI) tant que le
+# pixel n'existe pas, sans polluer le pixel actuel.
+NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT=votre_pixel_id_soumissionconfort
+META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT=votre_token_capi_soumissionconfort
+META_TEST_EVENT_CODE_SOUMISSIONCONFORT=  # optionnel — Events Manager → Test Events
+
 
 # ============================================================================
 # CRM / WEBHOOKS

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -38,8 +38,11 @@ META_PIXEL_ID=votre_pixel_id
 # séparé du pixel Niku → audience isolation 100% clean.
 # Placeholder XXXXXX = skip strict (aucun pixel browser, aucun CAPI) tant que le
 # pixel n'existe pas, sans polluer le pixel actuel.
-NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT=votre_pixel_id_soumissionconfort
-META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT=votre_token_capi_soumissionconfort
+# XXXXXX = placeholder reconnu par le garde-fou (skip strict). Remplacer par les
+# vraies valeurs en prod/preview. NE PAS mettre un texte libre type "votre_..."
+# ici : il ne matche pas /^X+$/ et le code tenterait de l'utiliser comme pixel.
+NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT=XXXXXX
+META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT=XXXXXX
 META_TEST_EVENT_CODE_SOUMISSIONCONFORT=  # optionnel — Events Manager → Test Events
 
 

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -206,6 +206,14 @@ export async function POST(request: NextRequest) {
               isolation_actuelle: leadData.userAnswers?.currentInsulation,
               acces_entretoit: leadData.userAnswers?.atticAccess,
               systeme_de_chauffage: leadData.userAnswers?.heatingSystem,
+              // V2 funnel fields — wired Phase 2 (IDs in GHL_FIELDS_ISO 41-43).
+              // V1 defaults above are kept for backward-compat with existing
+              // GHL workflows; these add the real V2 answers alongside.
+              symptoms: Array.isArray(leadData.userAnswers?.symptoms)
+                ? leadData.userAnswers.symptoms.join(',')
+                : leadData.userAnswers?.symptoms,
+              hydro_bracket: leadData.userAnswers?.hydroBracket,
+              intent: leadData.userAnswers?.intent,
               problemes_identifies: Array.isArray(leadData.userAnswers?.identifiedProblems)
                 ? leadData.userAnswers.identifiedProblems.join(', ')
                 : leadData.userAnswers?.identifiedProblems,
@@ -246,6 +254,19 @@ export async function POST(request: NextRequest) {
           },
         }
 
+        // Phase 2 V2: dynamic qualification tag for the /analysis funnel.
+        //  - qualified → 'Lead Iso Hot' + drop 'Lead Iso Curieux' (override).
+        //  - curious   → 'Lead Iso Curieux' (no removal: once hot, stays hot —
+        //    qualified→curious does NOT strip 'Lead Iso Hot', Zack v2 décision 8).
+        if (vertical === 'isolation' && leadData.userAnswers?.intent) {
+          if (leadData.userAnswers.intent === 'qualified') {
+            ghlPayload.tagOverride = 'Lead Iso Hot'
+            ghlPayload.tagsToRemove = ['Lead Iso Curieux']
+          } else if (leadData.userAnswers.intent === 'curious') {
+            ghlPayload.tagOverride = 'Lead Iso Curieux'
+          }
+        }
+
         const ghlResult = await postLeadToGHL(ghlPayload)
         console.log('🟢 LEADS API: GHL post result:', ghlResult)
 
@@ -266,11 +287,37 @@ export async function POST(request: NextRequest) {
         // the GHL cutover. The legacy block at the bottom of this file is
         // skipped by the early return below; without this duplicate, GHL
         // contacts wouldn't get a Meta Lead event.
+        //
+        // Phase 2 V2: for vertical='isolation' (the /analysis funnel) the Lead
+        // routes to the DEDICATED soumissionconfort pixel and is gated by
+        // intent === 'qualified'. Every other vertical stays on the shared
+        // pixel, ungated, exactly as before.
         try {
-          const metaPixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID
-          const metaAccessToken = process.env.META_CONVERSION_ACCESS_TOKEN
-          if (metaPixelId && metaAccessToken) {
-            const metaAPI = initializeMetaConversionAPI(metaPixelId, metaAccessToken)
+          const useSoumissionConfortPixel = vertical === 'isolation'
+          const metaPixelId = useSoumissionConfortPixel
+            ? process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT
+            : process.env.NEXT_PUBLIC_META_PIXEL_ID
+          const metaAccessToken = useSoumissionConfortPixel
+            ? process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT
+            : process.env.META_CONVERSION_ACCESS_TOKEN
+          const metaTestEventCode = useSoumissionConfortPixel
+            ? process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT
+            : process.env.META_TEST_EVENT_CODE
+
+          const isPlaceholder = (v?: string) => !!v && /^X+$/i.test(v)
+          // Only the isolation funnel is intent-gated; other verticals always fire.
+          const intentGateOk = !useSoumissionConfortPixel
+            || leadData.userAnswers?.intent === 'qualified'
+          // isTest gate (Zack v2 décision 7): replay/debug payloads never reach Meta.
+          const isTestLead = leadData.isTest === true
+
+          if (
+            !isTestLead
+            && metaPixelId && metaAccessToken
+            && !isPlaceholder(metaPixelId) && !isPlaceholder(metaAccessToken)
+            && intentGateOk
+          ) {
+            const metaAPI = initializeMetaConversionAPI(metaPixelId, metaAccessToken, metaTestEventCode)
             const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0] ||
                              request.headers.get('x-real-ip') || 'unknown'
             const userAgent = request.headers.get('user-agent') || 'unknown'
@@ -311,7 +358,13 @@ export async function POST(request: NextRequest) {
               eventId: leadData.eventId || undefined,
               customData: { service_type: serviceType },
             })
-            console.log(`✅ LEADS API: Meta CAPI event sent (GHL branch, ${serviceType})`)
+            console.log(`✅ LEADS API: Meta CAPI Lead sent (GHL branch, ${serviceType}, pixel=${useSoumissionConfortPixel ? 'soumissionconfort' : 'shared'})`)
+          } else if (isTestLead) {
+            console.log('[leads] skip Meta CAPI Lead — isTest=true')
+          } else if (useSoumissionConfortPixel && !intentGateOk) {
+            console.log('[leads] skip Meta CAPI Lead — intent !== qualified')
+          } else if (useSoumissionConfortPixel && (isPlaceholder(metaPixelId) || isPlaceholder(metaAccessToken))) {
+            console.warn('[leads] skip Meta CAPI Lead — soumissionconfort pixel/token is placeholder XXXXXX')
           } else {
             console.warn('⚠️ LEADS API: Meta CAPI not configured (GHL branch)')
           }
@@ -744,21 +797,43 @@ export async function POST(request: NextRequest) {
         console.error('❌ LEADS API: All webhooks failed')
       }
       
-      // Server-side Meta Conversion API tracking for ALL lead types
+      // Server-side Meta Conversion API tracking for ALL lead types.
+      // NOTE: this legacy Make path is NOT executed in prod (GHL_ENABLED=true),
+      // but we mirror the GHL-branch gating for consistency: isolation routes to
+      // the dedicated pixel + intent gate, others stay on the shared pixel,
+      // and isTest leads never reach Meta.
       if (successfulWebhooks > 0) {
         try {
-          const metaPixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID
-          const metaAccessToken = process.env.META_CONVERSION_ACCESS_TOKEN
-          
-          if (metaPixelId && metaAccessToken) {
-            const metaAPI = initializeMetaConversionAPI(metaPixelId, metaAccessToken)
-            
+          const useSoumissionConfortPixel = leadType === 'isolation'
+          const metaPixelId = useSoumissionConfortPixel
+            ? process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT
+            : process.env.NEXT_PUBLIC_META_PIXEL_ID
+          const metaAccessToken = useSoumissionConfortPixel
+            ? process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT
+            : process.env.META_CONVERSION_ACCESS_TOKEN
+          const metaTestEventCode = useSoumissionConfortPixel
+            ? process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT
+            : process.env.META_TEST_EVENT_CODE
+
+          const isPlaceholder = (v?: string) => !!v && /^X+$/i.test(v)
+          const intentGateOk = !useSoumissionConfortPixel
+            || leadData.userAnswers?.intent === 'qualified'
+          const isTestLead = leadData.isTest === true
+
+          if (
+            !isTestLead
+            && metaPixelId && metaAccessToken
+            && !isPlaceholder(metaPixelId) && !isPlaceholder(metaAccessToken)
+            && intentGateOk
+          ) {
+            const metaAPI = initializeMetaConversionAPI(metaPixelId, metaAccessToken, metaTestEventCode)
+
             // Get client IP and user agent from request headers
-            const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0] || 
-                            request.headers.get('x-real-ip') || 
+            const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0] ||
+                            request.headers.get('x-real-ip') ||
                             'unknown'
             const userAgent = request.headers.get('user-agent') || 'unknown'
-            
+
             // Determine service_type and value based on lead type
             const serviceTypeMap: Record<string, string> = {
               'isolation': 'isolation',
@@ -767,11 +842,11 @@ export async function POST(request: NextRequest) {
               'hvac': 'thermopompe',
             }
             const serviceType = serviceTypeMap[leadType] || 'isolation'
-            
+
             // Calculate estimated value for tracking
             let estimatedValue = 0
             if (isHVAC) {
-              estimatedValue = leadData.estimatedPrice || 
+              estimatedValue = leadData.estimatedPrice ||
                               ((leadData.estimatedPriceMin || 0) + (leadData.estimatedPriceMax || 0)) / 2
             } else if (isSubvention) {
               estimatedValue = 1500 // Subvention value
@@ -781,7 +856,7 @@ export async function POST(request: NextRequest) {
               const stdMax = leadData.pricingData?.ranges?.standard?.totalCost?.max || 0
               estimatedValue = (stdMin + stdMax) / 2
             }
-            
+
             // Determine source URL based on lead type
             const sourceUrlMap: Record<string, string> = {
               'isolation': '/analysis',
@@ -790,9 +865,9 @@ export async function POST(request: NextRequest) {
             }
             const sourcePath = sourceUrlMap[leadType] || '/'
             const origin = request.headers.get('origin') || 'https://soumissionconfort.ai'
-            
-            console.log(`📊 LEADS API: Sending server-side Meta Lead event for ${serviceType} (eventId: ${leadData.eventId || 'none'})`)
-            
+
+            console.log(`📊 LEADS API: Sending server-side Meta Lead event for ${serviceType} (eventId: ${leadData.eventId || 'none'}, pixel=${useSoumissionConfortPixel ? 'soumissionconfort' : 'shared'})`)
+
             await metaAPI.trackLead({
               email: leadData.email,
               phone: leadData.phone,
@@ -807,8 +882,14 @@ export async function POST(request: NextRequest) {
                 service_type: serviceType
               }
             })
-            
+
             console.log(`✅ LEADS API: Server-side Meta Lead event sent successfully for ${serviceType}`)
+          } else if (isTestLead) {
+            console.log('[leads] skip Meta CAPI Lead — isTest=true (legacy path)')
+          } else if (useSoumissionConfortPixel && !intentGateOk) {
+            console.log('[leads] skip Meta CAPI Lead — intent !== qualified (legacy path)')
+          } else if (useSoumissionConfortPixel && (isPlaceholder(metaPixelId) || isPlaceholder(metaAccessToken))) {
+            console.warn('[leads] skip Meta CAPI Lead — soumissionconfort pixel/token is placeholder XXXXXX (legacy path)')
           } else {
             console.warn('⚠️ LEADS API: Meta Pixel credentials not configured for server-side tracking')
           }

--- a/app/api/meta/view-content/route.ts
+++ b/app/api/meta/view-content/route.ts
@@ -1,0 +1,48 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { MetaConversionAPI } from '@/lib/meta-conversion-api'
+import {
+  META_CONFIG_SOUMISSIONCONFORT,
+  isSoumissionConfortMetaConfigured,
+} from '@/lib/meta-config'
+
+// CAPI ViewContent for the /analysis wizard → dedicated soumissionconfort
+// pixel only. Browser fbq fires the matching ViewContent with the same eventId
+// (see user-questionnaire-wizard.tsx) so Meta dedups to a single event.
+//
+// Skips silently when the dedicated pixel isn't configured yet (placeholder
+// rollout window) — never falls back to the shared pixel.
+export async function POST(request: NextRequest) {
+  if (!isSoumissionConfortMetaConfigured()) {
+    console.warn('[view-content] Meta CAPI not configured for soumissionconfort (skip)')
+    return NextResponse.json({ skipped: true })
+  }
+
+  try {
+    const { eventId, sourceUrl, address } = await request.json()
+    const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0]
+      || request.headers.get('x-real-ip')
+      || 'unknown'
+    const userAgent = request.headers.get('user-agent') || 'unknown'
+
+    const metaAPI = new MetaConversionAPI(
+      META_CONFIG_SOUMISSIONCONFORT.PIXEL_ID,
+      META_CONFIG_SOUMISSIONCONFORT.ACCESS_TOKEN,
+      META_CONFIG_SOUMISSIONCONFORT.TEST_EVENT_CODE,
+    )
+
+    await metaAPI.trackViewContent({
+      eventId,
+      sourceUrl,
+      clientIp,
+      userAgent,
+      contentName: 'analysis-wizard-v2',
+      contentType: 'isolation',
+      searchString: address,
+    })
+
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('[view-content] CAPI error', err)
+    return NextResponse.json({ ok: false }, { status: 500 })
+  }
+}

--- a/app/api/test-meta/route.ts
+++ b/app/api/test-meta/route.ts
@@ -41,7 +41,7 @@ export async function POST(request: NextRequest) {
 
     // Test ViewContent event
     console.log('🧪 Testing ViewContent event...')
-    const viewContentResult = await trackViewContent('Test Page', 'test')
+    const viewContentResult = await trackViewContent({ contentName: 'Test Page', contentType: 'test' })
     console.log('📊 ViewContent Result:', viewContentResult)
 
     // Test Lead event with sample data

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Radio_Canada_Big, Source_Serif_4 } from 'next/font/google'
 import "./globals.css"
 import { LanguageProvider } from "@/lib/language-context"
 import { Analytics } from "@vercel/analytics/next"
+import { MetaPixelRouter } from "@/components/meta-pixel-router"
 
 const radioCanadaBig = Radio_Canada_Big({
   subsets: ["latin"],
@@ -163,38 +164,12 @@ export default function RootLayout({
           }}
         />
 
-        {process.env.NEXT_PUBLIC_META_PIXEL_ID && (
-          <>
-            {/* Meta Pixel Code */}
-            <script
-              dangerouslySetInnerHTML={{
-                __html: `
-                  !function(f,b,e,v,n,t,s)
-                  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-                  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-                  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-                  n.queue=[];t=b.createElement(e);t.async=!0;
-                  t.src=v;s=b.getElementsByTagName(e)[0];
-                  s.parentNode.insertBefore(t,s)}(window, document,'script',
-                  'https://connect.facebook.net/en_US/fbevents.js');
-                  fbq('init', '` + process.env.NEXT_PUBLIC_META_PIXEL_ID + `');
-                  fbq('track', 'PageView');
-                `
-              }}
-            />
-            <noscript>
-              <img 
-                height="1" 
-                width="1" 
-                style={{display:'none'}}
-                src={`https://www.facebook.com/tr?id=${process.env.NEXT_PUBLIC_META_PIXEL_ID}&ev=PageView&noscript=1`}
-              />
-            </noscript>
-            {/* End Meta Pixel Code */}
-          </>
-        )}
       </head>
       <body className={`${radioCanadaBig.variable} ${sourceSerif4.variable}`}>
+        {/* Route-aware Meta Pixel: shared Niku pixel everywhere, dedicated
+            soumissionconfort pixel on the /analysis funnel only (Phase 2 V2).
+            Replaces the old inline <script> that loaded a single pixel. */}
+        <MetaPixelRouter />
         <LanguageProvider>{children}</LanguageProvider>
         <Analytics />
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -74,7 +74,7 @@ export default function HomePage() {
   useEffect(() => {
     initializeMeta()
     if (isMetaConfigured()) {
-      trackViewContent('Homepage', 'website').catch(() => {})
+      trackViewContent({ contentName: 'Homepage', contentType: 'website' }).catch(() => {})
     }
   }, [])
 

--- a/app/soumission-rapide/merci/page.tsx
+++ b/app/soumission-rapide/merci/page.tsx
@@ -68,12 +68,6 @@ export default function MerciPage() {
       if (stored) setLeadData(JSON.parse(stored))
     } catch { /* ignore */ }
 
-    if (typeof window.fbq === "function") {
-      window.fbq("track", "CompleteRegistration", {
-        content_name: "soumission-rapide-isolation",
-        currency: "CAD",
-      })
-    }
     if (typeof window.gtag === "function") {
       window.gtag("event", "conversion", { event_category: "pSEO Questionnaire", event_label: "merci_page_view" })
       window.gtag("event", "merci_page_view", { event_category: "pSEO Questionnaire" })

--- a/app/soumission-rapide/questionnaire/page.tsx
+++ b/app/soumission-rapide/questionnaire/page.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 import { Suspense, useState, useEffect, useCallback, useRef } from "react"
 import { useSearchParams, useRouter } from "next/navigation"
+import { META_PIXEL_PARTAGE } from "@/components/meta-pixel-router"
 import Link from "next/link"
 import { ArrowLeft, CheckCircle, Loader2, MapPin } from "lucide-react"
 import { getCurrentUTMParameters, type UTMParameters } from "@/lib/utm-utils"
@@ -99,8 +100,16 @@ function trackStepEvent(stepNumber: number, stepName: string, stepValue: string)
       step_value: stepValue,
     })
   }
-  if (typeof window !== "undefined" && typeof window.fbq === "function") {
-    window.fbq("trackCustom", "QuestionnaireStep", {
+  // trackSingleCustom targets the SHARED pixel only — a plain trackCustom()
+  // would also reach the dedicated soumissionconfort pixel if the user crossed
+  // /analysis earlier this session.
+  if (
+    typeof window !== "undefined" &&
+    typeof window.fbq === "function" &&
+    META_PIXEL_PARTAGE &&
+    !/^X+$/i.test(META_PIXEL_PARTAGE)
+  ) {
+    window.fbq("trackSingleCustom", META_PIXEL_PARTAGE, "QuestionnaireStep", {
       step_number: stepNumber,
       step_name: stepName,
       step_value: stepValue,
@@ -358,9 +367,15 @@ function QuestionnaireContent() {
       }
 
       // Meta Pixel — Lead event (fire client-side regardless of when the
-      // API call happens; final dedup via server-side eventId).
-      if (typeof window.fbq === "function") {
-        window.fbq("track", "Lead", {
+      // API call happens; final dedup via server-side eventId). trackSingle
+      // targets the SHARED pixel only so this soumission-rapide Lead never
+      // reaches the dedicated isolation pixel.
+      if (
+        typeof window.fbq === "function" &&
+        META_PIXEL_PARTAGE &&
+        !/^X+$/i.test(META_PIXEL_PARTAGE)
+      ) {
+        window.fbq("trackSingle", META_PIXEL_PARTAGE, "Lead", {
           currency: "CAD",
           content_name: "isolation-soumission-rapide",
           ...(utmParams.utm_source && { utm_source: utmParams.utm_source }),

--- a/app/subventions/page.tsx
+++ b/app/subventions/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { useRouter } from "next/navigation"
+import { META_PIXEL_PARTAGE } from "@/components/meta-pixel-router"
 import { AddressInput } from "@/components/address-input"
 import { HowItWorks } from "@/components/how-it-works"
 import { ReviewsSection } from "@/components/reviews-section"
@@ -224,10 +225,19 @@ export default function SubventionsPage() {
     const eventId = crypto.randomUUID()
 
     try {
-      // Fire Meta Pixel (client-side) with shared eventId for dedup
-      if (typeof window !== "undefined" && (window as any).fbq) {
+      // Fire Meta Pixel (client-side) with shared eventId for dedup.
+      // trackSingle targets the SHARED pixel only — a plain track() would also
+      // hit the dedicated soumissionconfort pixel if the user crossed /analysis
+      // earlier this session, polluting the isolation audience.
+      if (
+        typeof window !== "undefined" &&
+        typeof (window as any).fbq === "function" &&
+        META_PIXEL_PARTAGE &&
+        !/^X+$/i.test(META_PIXEL_PARTAGE)
+      ) {
         ;(window as any).fbq(
-          "track",
+          "trackSingle",
+          META_PIXEL_PARTAGE,
           "Lead",
           { service_type: "subvention" },
           { eventID: eventId }

--- a/app/thermopompes/page.tsx
+++ b/app/thermopompes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
+import { META_PIXEL_PARTAGE } from "@/components/meta-pixel-router"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -264,9 +265,17 @@ export default function ThermopompesPage() {
     // Generate shared eventId for client/server deduplication
     const eventId = crypto.randomUUID();
 
-    // Facebook Pixel tracking (client-side) — fire before API for reliability
-    if (typeof window !== 'undefined' && (window as any).fbq) {
-      (window as any).fbq('track', 'Lead', {
+    // Facebook Pixel tracking (client-side) — fire before API for reliability.
+    // trackSingle targets the SHARED pixel only: a plain track() would fan out
+    // to the dedicated soumissionconfort pixel too if the user crossed the
+    // /analysis funnel earlier this session, polluting the isolation audience.
+    if (
+      typeof window !== 'undefined'
+      && typeof (window as any).fbq === 'function'
+      && META_PIXEL_PARTAGE
+      && !/^X+$/i.test(META_PIXEL_PARTAGE)
+    ) {
+      (window as any).fbq('trackSingle', META_PIXEL_PARTAGE, 'Lead', {
         service_type: 'thermopompe'
       }, { eventID: eventId });
     }

--- a/app/verifier-telephone/page.tsx
+++ b/app/verifier-telephone/page.tsx
@@ -5,6 +5,13 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { CheckCircle, Loader2 } from "lucide-react"
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp"
+import { META_PIXEL_DEDIE } from "@/components/meta-pixel-router"
+
+declare global {
+  interface Window {
+    fbq: (...args: any[]) => void
+  }
+}
 
 type State = "sending" | "pending" | "confirming" | "submitting" | "verified" | "error"
 
@@ -178,6 +185,38 @@ export default function VerifierTelephonePage() {
           setState("error")
         }
         return
+      }
+
+      // OTP confirmed + lead persisted → NOW fire the Meta browser Lead.
+      // /verifier-telephone is shared across funnels, but only the analysis
+      // lead form stashes `meta.intent`, so this gate fires for isolation leads
+      // ONLY (thermopompes/subventions payloads have no meta.intent). For those
+      // analysis leads, MetaPixelRouter has loaded the dedicated pixel
+      // (otp-verify.source==='analysis'); we still target it explicitly with
+      // trackSingle. Same eventId as the CAPI Lead (/api/leads) → Meta dedups.
+      try {
+        const pendingRaw = sessionStorage.getItem("pending-lead")
+        if (pendingRaw) {
+          const pending = JSON.parse(pendingRaw)
+          if (
+            pending?.meta?.intent === "qualified" &&
+            typeof window !== "undefined" &&
+            typeof window.fbq === "function" &&
+            META_PIXEL_DEDIE &&
+            !/^X+$/i.test(META_PIXEL_DEDIE)
+          ) {
+            const leadEventId =
+              pending.eventId ||
+              ("randomUUID" in crypto ? crypto.randomUUID() : `lead-${Date.now()}`)
+            window.fbq("trackSingle", META_PIXEL_DEDIE, "Lead", {
+              value: Number(pending.meta.estimatedValue || 0).toFixed(2),
+              currency: "CAD",
+              service_type: "isolation",
+            }, { eventID: leadEventId })
+          }
+        }
+      } catch (err) {
+        console.warn("post-OTP Lead pixel failed", err)
       }
 
       setState("verified")

--- a/components/lead-capture-form.tsx
+++ b/components/lead-capture-form.tsx
@@ -11,6 +11,7 @@ import { isValidQuebecPhone } from "@/lib/phone"
 import { getCurrentUTMParameters, type UTMParameters } from "@/lib/utm-utils"
 import { buildV1AnswersFromV2, type V2Answers } from "@/lib/funnel-config"
 import { calculateInsulationPricing } from "@/lib/insulation-calculator"
+import { META_PIXEL_DEDIE } from "@/components/meta-pixel-router"
 
 declare global {
   interface Window {
@@ -106,6 +107,12 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
       intent: v2Answers.intent,
     }
 
+    // Estimated lead value (standard range midpoint) — carried in pending.meta
+    // so /verifier-telephone can fire the post-OTP Lead pixel with the same value.
+    const estimatedValue = pricingData?.ranges?.standard
+      ? (pricingData.ranges.standard.totalCost.min + pricingData.ranges.standard.totalCost.max) / 2
+      : 0
+
     const leadPayload = {
       firstName: formData.firstName,
       lastName: formData.lastName,
@@ -116,25 +123,21 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
       userAnswers: userAnswersPayload,
       pricingData,
       utmParams,
+      // eventId stays top-level: /api/leads reads leadData.eventId for the CAPI
+      // Lead, and /verifier-telephone reads pending.eventId for the browser
+      // Lead → same id → Meta dedups browser↔CAPI (P0-3).
       eventId,
+      // Phase 2: drives the post-OTP browser Lead gate + value on /verifier-telephone.
+      meta: {
+        intent: v2Answers.intent,
+        estimatedValue,
+      },
     }
 
-    // Fire Meta browser Lead pixel ONLY for qualified intent — curious leads
-    // pollute the optim audience. Server CAPI is similarly gated Phase 2 in /api/leads.
-    if (
-      v2Answers.intent === 'qualified' &&
-      typeof window !== 'undefined' &&
-      typeof window.fbq === 'function' &&
-      pricingData?.ranges?.standard
-    ) {
-      const range = pricingData.ranges.standard
-      const estimatedValue = (range.totalCost.min + range.totalCost.max) / 2
-      window.fbq('track', 'Lead', {
-        value: estimatedValue.toFixed(2),
-        currency: 'CAD',
-        service_type: 'isolation',
-      }, { eventID: eventId })
-    }
+    // NOTE (Phase 2): the Meta browser Lead pixel is NO LONGER fired here.
+    // It moved past the OTP gate — qualified + form submitted + OTP confirmed —
+    // so we never declare a Lead for an unverified phone. Fired from
+    // /verifier-telephone (OTP path) or after /api/leads 200 (non-OTP path below).
 
     const leadDataForReturn: LeadData = {
       firstName: formData.firstName,
@@ -159,7 +162,11 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
         }))
         const pricingUrl = `/pricing?leadId=${clientLeadId}&d=${urlData}`
         sessionStorage.setItem('pending-lead', JSON.stringify(leadPayload))
-        sessionStorage.setItem('otp-verify', JSON.stringify({ phone: formData.phone, redirectTo: pricingUrl }))
+        // source:'analysis' lets MetaPixelRouter load the DEDICATED pixel on the
+        // shared /verifier-telephone page for THIS funnel only. Thermopompes /
+        // subventions leads also land on /verifier-telephone but never set this
+        // flag → they stay on the shared pixel → zero cross-funnel contamination.
+        sessionStorage.setItem('otp-verify', JSON.stringify({ phone: formData.phone, redirectTo: pricingUrl, source: 'analysis' }))
         router.push('/verifier-telephone')
         return
       }
@@ -174,6 +181,25 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
         console.error('❌ /api/leads error', response.status, errorText)
         throw new Error(`API call failed: ${response.status}`)
       }
+
+      // Non-OTP path (OTP_ENABLED=false): fire the browser Lead AFTER /api/leads
+      // succeeds — qualified intent only, same eventId as the CAPI Lead, targeted
+      // at the dedicated pixel (trackSingle). When OTP is on, this fires from
+      // /verifier-telephone instead (we return before reaching here).
+      if (
+        v2Answers.intent === 'qualified' &&
+        typeof window !== 'undefined' &&
+        typeof window.fbq === 'function' &&
+        META_PIXEL_DEDIE &&
+        !/^X+$/i.test(META_PIXEL_DEDIE)
+      ) {
+        window.fbq('trackSingle', META_PIXEL_DEDIE, 'Lead', {
+          value: estimatedValue.toFixed(2),
+          currency: 'CAD',
+          service_type: 'isolation',
+        }, { eventID: eventId })
+      }
+
       onComplete(pricingData, leadDataForReturn, clientLeadId)
     } catch (error) {
       console.error('❌ Lead submission error:', error)

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -10,8 +10,16 @@ import { usePathname } from 'next/navigation'
 // invariant: a PageView fires to EXACTLY ONE pixel per route, and the dedicated
 // soumissionconfort pixel ONLY ever sees the isolation /analysis funnel.
 //   - /analysis*                          → dedicated pixel
+//   - /pricing                            → dedicated pixel (iso results page)
 //   - /verifier-telephone (analysis only) → dedicated pixel
 //   - everything else                     → shared Niku pixel (status quo)
+//
+// /pricing is the isolation results page (InsulationResults). It's reached ONLY
+// from the analysis lead form (lead-capture-form.tsx redirects there post-OTP),
+// so unlike /verifier-telephone it's classified by pathname alone — no source
+// marker needed, no cross-funnel ambiguity. Without this, the bottom-funnel
+// results PageView would leak onto the shared pixel (otp-verify is already
+// cleared by the time we land here, so a session-marker gate wouldn't work).
 //
 // /verifier-telephone is SHARED across funnels (analysis, thermopompes,
 // subventions all router.push there). Classifying it by pathname alone would
@@ -43,9 +51,12 @@ function isPlaceholder(v: string): boolean {
 }
 
 // True for routes that are UNCONDITIONALLY part of the analysis funnel (the
-// wizard pages). /verifier-telephone is handled separately because it's shared.
+// wizard pages + the /pricing results page). /verifier-telephone is handled
+// separately because it's shared across funnels.
 export function isAnalysisWizardRoute(pathname: string): boolean {
-  return pathname === '/analysis' || pathname.startsWith('/analysis/')
+  return pathname === '/analysis'
+    || pathname.startsWith('/analysis/')
+    || pathname === '/pricing'
 }
 
 // Reads the OTP source marker the analysis lead form stamps in sessionStorage.

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useEffect, useRef } from 'react'
+import Script from 'next/script'
+import { usePathname } from 'next/navigation'
+
+// Phase 2 V2 — route-aware Meta Pixel loader.
+//
+// One <MetaPixelRouter /> is mounted once in app/layout.tsx. It guarantees the
+// invariant: a PageView fires to EXACTLY ONE pixel per route, and the dedicated
+// soumissionconfort pixel ONLY ever sees the isolation /analysis funnel.
+//   - /analysis*                          → dedicated pixel
+//   - /verifier-telephone (analysis only) → dedicated pixel
+//   - everything else                     → shared Niku pixel (status quo)
+//
+// /verifier-telephone is SHARED across funnels (analysis, thermopompes,
+// subventions all router.push there). Classifying it by pathname alone would
+// leak HVAC/subvention OTP PageViews onto the dedicated pixel. So we gate it on
+// sessionStorage `otp-verify.source === 'analysis'`, which only the analysis
+// lead form sets (components/lead-capture-form.tsx). Zero cross-funnel
+// contamination: a thermopompe lead on /verifier-telephone never sets that
+// flag → stays on the shared pixel.
+//
+// Why trackSingle (not two <Script> blocks): the fbq bootstrap starts with
+// `if(f.fbq)return`, so a second `fbq('init', X)` ADDS a pixel rather than
+// replacing it, and a plain `fbq('track', 'PageView')` then fires to BOTH
+// pixels. We init each pixel once and fire every PageView with
+// `trackSingle(<pixelId>, ...)` to the route's pixel only.
+
+// Exported so the OTHER funnels (thermopompes/subventions/soumission-rapide)
+// can fire their events with trackSingle(<shared>, ...) instead of a global
+// fbq('track', ...), which would fan out to the dedicated pixel too once a
+// user has crossed the /analysis funnel in the same session. Single source of
+// truth — call sites can't accidentally target the wrong pixel.
+export const META_PIXEL_PARTAGE = process.env.NEXT_PUBLIC_META_PIXEL_ID || ''
+const PIXEL_PARTAGE = META_PIXEL_PARTAGE
+// Exported so the wizard ViewContent + post-OTP Lead can target the dedicated
+// pixel with trackSingle (browser dedup vs CAPI).
+export const META_PIXEL_DEDIE = process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT || ''
+
+function isPlaceholder(v: string): boolean {
+  return !v || /^X+$/i.test(v)
+}
+
+// True for routes that are UNCONDITIONALLY part of the analysis funnel (the
+// wizard pages). /verifier-telephone is handled separately because it's shared.
+export function isAnalysisWizardRoute(pathname: string): boolean {
+  return pathname === '/analysis' || pathname.startsWith('/analysis/')
+}
+
+// Reads the OTP source marker the analysis lead form stamps in sessionStorage.
+// Only meaningful on /verifier-telephone, and only client-side.
+function otpSourceIsAnalysis(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    const raw = sessionStorage.getItem('otp-verify')
+    if (!raw) return false
+    return JSON.parse(raw)?.source === 'analysis'
+  } catch {
+    return false
+  }
+}
+
+// Whether the CURRENT route belongs to the isolation /analysis funnel and so
+// should load the dedicated pixel. Must run client-side (reads sessionStorage).
+export function inAnalysisFunnelClient(pathname: string): boolean {
+  if (isAnalysisWizardRoute(pathname)) return true
+  if (pathname === '/verifier-telephone') return otpSourceIsAnalysis()
+  return false
+}
+
+export function MetaPixelRouter() {
+  const pathname = usePathname()
+  // Track which pixels we've already `init`-ed so we never double-init.
+  const initedRef = useRef<Set<string>>(new Set())
+  // Guard against StrictMode double-effect / duplicate PageView per route.
+  const lastPageViewRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.fbq !== 'function') return
+
+    const inFunnel = inAnalysisFunnelClient(pathname)
+    // Strict guard (Zack v2 décision 5): on the /analysis funnel, if the
+    // dedicated pixel is missing/placeholder, fire NOTHING — never leak the
+    // funnel onto the shared pixel during rollout.
+    const pixelForRoute = inFunnel ? META_PIXEL_DEDIE : PIXEL_PARTAGE
+    if (isPlaceholder(pixelForRoute)) return
+
+    // Init this pixel once (idempotent across navigations).
+    if (!initedRef.current.has(pixelForRoute)) {
+      window.fbq('init', pixelForRoute)
+      initedRef.current.add(pixelForRoute)
+    }
+
+    // Fire PageView to THIS pixel only — never the other one. The dedupe key
+    // pins it to (pixel, pathname) so StrictMode's double effect doesn't send
+    // two PageViews for the same route in dev.
+    const pageViewKey = `${pixelForRoute}:${pathname}`
+    if (lastPageViewRef.current !== pageViewKey) {
+      lastPageViewRef.current = pageViewKey
+      window.fbq('trackSingle', pixelForRoute, 'PageView')
+    }
+  }, [pathname])
+
+  // The bootstrap snippet loads the fbq library exactly once for the whole
+  // app. We deliberately do NOT call fbq('init'/'track') inside it — the
+  // useEffect above owns init + PageView so the single-pixel invariant holds
+  // on every route, including the very first paint.
+  if (isPlaceholder(PIXEL_PARTAGE) && isPlaceholder(META_PIXEL_DEDIE)) return null
+
+  return (
+    <>
+      <Script id="meta-pixel-bootstrap" strategy="afterInteractive">
+        {`
+          !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+          n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+          n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+          document,'script','https://connect.facebook.net/en_US/fbevents.js');
+        `}
+      </Script>
+      {/* noscript fallback uses the shared pixel — the no-JS case never reaches
+          the SPA /analysis funnel anyway (no wizard, no lead form). */}
+      {!isPlaceholder(PIXEL_PARTAGE) && (
+        <noscript>
+          <img height="1" width="1" style={{ display: 'none' }}
+            src={`https://www.facebook.com/tr?id=${PIXEL_PARTAGE}&ev=PageView&noscript=1`} alt="" />
+        </noscript>
+      )}
+    </>
+  )
+}

--- a/components/user-questionnaire-wizard.tsx
+++ b/components/user-questionnaire-wizard.tsx
@@ -13,6 +13,13 @@ import {
   type HydroBracketCode,
   type IntentCode,
 } from "@/lib/funnel-config"
+import { META_PIXEL_DEDIE } from "@/components/meta-pixel-router"
+
+declare global {
+  interface Window {
+    fbq: (...args: any[]) => void
+  }
+}
 
 interface UserQuestionnaireProps {
   roofData: any
@@ -42,6 +49,49 @@ export function UserQuestionnaire({ roofData: _roofData, onComplete }: UserQuest
     return () => {
       if (advanceTimeoutRef.current) clearTimeout(advanceTimeoutRef.current)
     }
+  }, [])
+
+  // ViewContent fires ONCE when the wizard mounts — this is the moment the user
+  // "starts the application" (after the roof-analysis loading). Browser fbq +
+  // CAPI share the same eventId so Meta dedups to 1 event. Dedicated pixel only
+  // (we're on /analysis → MetaPixelRouter has loaded the dedicated pixel; we
+  // target it explicitly with trackSingleCustom to stay isolated even if the
+  // shared pixel is also initialised from a prior route).
+  const viewContentFiredRef = useRef(false)
+  useEffect(() => {
+    if (viewContentFiredRef.current) return
+    viewContentFiredRef.current = true
+
+    const eventId = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `vc-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+    // Browser pixel ViewContent → dedicated pixel only. ViewContent is a Meta
+    // STANDARD event, so it's trackSingle (not trackSingleCustom).
+    if (
+      typeof window !== 'undefined'
+      && typeof window.fbq === 'function'
+      && META_PIXEL_DEDIE
+      && !/^X+$/i.test(META_PIXEL_DEDIE)
+    ) {
+      window.fbq('trackSingle', META_PIXEL_DEDIE, 'ViewContent', {
+        content_name: 'analysis-wizard-v2',
+        content_category: 'isolation',
+      }, { eventID: eventId })
+    }
+
+    // CAPI ViewContent → dedicated pixel (server-side), dedup via same eventId.
+    // keepalive guards against the event being dropped if the user navigates
+    // away quickly after mount.
+    fetch('/api/meta/view-content', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventId,
+        sourceUrl: typeof window !== 'undefined' ? window.location.href : undefined,
+      }),
+      keepalive: true,
+    }).catch(err => console.warn('ViewContent CAPI failed', err))
   }, [])
 
   const totalSteps = STEP_KEYS.length

--- a/lib/ghl-client.ts
+++ b/lib/ghl-client.ts
@@ -51,6 +51,12 @@ export interface NormalizedLead {
   internalLeadId?: string
   // Optional notes appended on creation
   noteBody?: string
+  // Phase 2 V2: replaces VERTICAL_TAG[vertical] on the contact when set
+  // (e.g. 'Lead Iso Hot' / 'Lead Iso Curieux' for the /analysis funnel).
+  tagOverride?: string
+  // Phase 2 V2: tags to remove after upsert (best-effort). Used for the
+  // curious→qualified override (drop 'Lead Iso Curieux' once hot).
+  tagsToRemove?: string[]
 }
 
 interface GHLContactPayload {
@@ -151,7 +157,13 @@ function buildContactPayload(
     postalCode: lead.postalCode,
     country: 'CA',
     source: lead.leadSource ?? lead.utmSource ?? 'vercel-direct',
-    tags: [VERTICAL_TAG[lead.vertical]],
+    // When a tagOverride is set (isolation V2 Hot/Curieux), DON'T put tags in
+    // the upsert: GHL's upsert REPLACES the whole tags array, which would wipe
+    // an existing 'Lead Iso Hot' on a qualified→curious re-submit (violates
+    // décision 8: once Hot, stays Hot). Instead postLeadToGHL adds the tag via
+    // POST /tags (idempotent, non-destructive). Other verticals keep the
+    // upsert tag (no Hot/Curieux state transitions → no overwrite risk).
+    ...(lead.tagOverride ? {} : { tags: [VERTICAL_TAG[lead.vertical]] }),
     customFields,
   }
 }
@@ -265,6 +277,44 @@ export async function postLeadToGHL(lead: NormalizedLead): Promise<GHLPostResult
       method: 'POST',
       body: JSON.stringify({ body: lead.noteBody }),
     })
+  }
+
+  // Phase 2 V2: isolation Hot/Curieux tag, added via POST /tags (NOT the upsert).
+  // POST /tags is additive + idempotent: it never wipes other tags, so a
+  // qualified→curious re-submit ADDS 'Lead Iso Curieux' while KEEPING any
+  // existing 'Lead Iso Hot' (décision 8: once Hot, stays Hot). The upsert tag
+  // was suppressed in buildContactPayload when tagOverride is set.
+  if (contactId && lead.tagOverride) {
+    const addRes = await ghlRequest(apiKey, `/contacts/${contactId}/tags`, {
+      method: 'POST',
+      body: JSON.stringify({ tags: [lead.tagOverride] }),
+    })
+    if (!addRes.ok) {
+      console.warn(`[ghl-client] tag add failed for ${contactId}:`, addRes.error)
+    }
+  }
+
+  // Phase 2 V2: remove stale tags after upsert (best-effort). Used for the
+  // curious→qualified override — a 'Lead Iso Curieux' contact re-submitting as
+  // qualified gets 'Lead Iso Hot' added above and 'Lead Iso Curieux' dropped
+  // here, so the contact carries a single source of truth. (One-way only:
+  // qualified→curious sets no tagsToRemove, preserving Hot per décision 8.)
+  //
+  // We never block / fail the lead on a tag-removal error — the contact + its
+  // hot tag are already persisted; a leftover curious tag is cosmetic.
+  //
+  // Endpoint: DELETE /contacts/{contactId}/tags. Body `{ tags: [...] }` is
+  // inferred from the ADD endpoint (the Remove docs don't spell out the body).
+  // Validate with a curl on a test contact in preview before prod; if the
+  // schema differs (e.g. query param), adjust here.
+  if (contactId && lead.tagsToRemove && lead.tagsToRemove.length > 0) {
+    const removeRes = await ghlRequest(apiKey, `/contacts/${contactId}/tags`, {
+      method: 'DELETE',
+      body: JSON.stringify({ tags: lead.tagsToRemove }),
+    })
+    if (!removeRes.ok) {
+      console.warn(`[ghl-client] tag removal failed for ${contactId}:`, removeRes.error)
+    }
   }
 
   return { contactId, duplicate, contactStatus: created.status }

--- a/lib/ghl-client.ts
+++ b/lib/ghl-client.ts
@@ -279,15 +279,21 @@ export async function postLeadToGHL(lead: NormalizedLead): Promise<GHLPostResult
     })
   }
 
-  // Phase 2 V2: isolation Hot/Curieux tag, added via POST /tags (NOT the upsert).
+  // Phase 2 V2: isolation tags added via POST /tags (NOT the upsert).
   // POST /tags is additive + idempotent: it never wipes other tags, so a
   // qualified→curious re-submit ADDS 'Lead Iso Curieux' while KEEPING any
   // existing 'Lead Iso Hot' (décision 8: once Hot, stays Hot). The upsert tag
   // was suppressed in buildContactPayload when tagOverride is set.
+  //
+  // We add BOTH the base vertical tag ('Lead Iso') AND the Hot/Curieux
+  // override: V1 leads + every other vertical keep 'Lead Iso' via the upsert,
+  // so V2 leads must too — otherwise existing GHL workflows/smartlists filtering
+  // on 'Lead Iso' would silently stop matching V2 leads. POST is idempotent so
+  // re-adding 'Lead Iso' on a duplicate is a no-op.
   if (contactId && lead.tagOverride) {
     const addRes = await ghlRequest(apiKey, `/contacts/${contactId}/tags`, {
       method: 'POST',
-      body: JSON.stringify({ tags: [lead.tagOverride] }),
+      body: JSON.stringify({ tags: [VERTICAL_TAG[lead.vertical], lead.tagOverride] }),
     })
     if (!addRes.ok) {
       console.warn(`[ghl-client] tag add failed for ${contactId}:`, addRes.error)

--- a/lib/meta-config.ts
+++ b/lib/meta-config.ts
@@ -28,3 +28,26 @@ export function initializeMeta() {
 export function isMetaConfigured(): boolean {
   return !!(META_CONFIG.PIXEL_ID && META_CONFIG.ACCESS_TOKEN);
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// Dedicated soumissionconfort pixel — funnel /analysis only (Phase 2 V2).
+// Separate Meta Business Manager pixel, cohabits with META_CONFIG (the Niku
+// shared pixel that keeps serving homepage/thermopompes/subventions/rapide).
+// ───────────────────────────────────────────────────────────────────────────
+export const META_CONFIG_SOUMISSIONCONFORT = {
+  PIXEL_ID: process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT || '',
+  ACCESS_TOKEN: process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT || '',
+  TEST_EVENT_CODE: process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT || undefined,
+};
+
+// True only when both id + token are real (not empty, not the XXXXXX
+// placeholder). Lets the CAPI routes skip silently during the rollout window
+// before the pixel exists, instead of POSTing garbage to Meta.
+export function isSoumissionConfortMetaConfigured(): boolean {
+  const id = META_CONFIG_SOUMISSIONCONFORT.PIXEL_ID;
+  const token = META_CONFIG_SOUMISSIONCONFORT.ACCESS_TOKEN;
+  if (!id || !token) return false;
+  // Guard against the XXXXXX placeholder Zack writes before the pixel exists.
+  if (/^X+$/i.test(id) || /^X+$/i.test(token)) return false;
+  return true;
+}

--- a/lib/meta-conversion-api.ts
+++ b/lib/meta-conversion-api.ts
@@ -98,21 +98,38 @@ export class MetaConversionAPI {
     this.testEventCode = testEventCode;
   }
 
-  // Track ViewContent event (when user enters website)
-  async trackViewContent(contentName?: string, contentType?: string) {
+  // Track ViewContent event. Accepts an object so the /analysis wizard can pass
+  // an eventId for browser↔CAPI dedup, plus server-side client info (ip/ua/url)
+  // that getClientInfo() can't supply outside the browser.
+  async trackViewContent(data: {
+    contentName?: string
+    contentType?: string
+    searchString?: string
+    eventId?: string
+    clientIp?: string
+    userAgent?: string
+    sourceUrl?: string
+  } = {}) {
+    // Prefer explicit server-passed client info; fall back to browser cookies
+    // (_fbp/_fbc) + UA when called client-side.
+    const userData: NonNullable<MetaConversionEvent['user_data']> = { ...getClientInfo() };
+    if (data.clientIp) userData.client_ip_address = data.clientIp;
+    if (data.userAgent) userData.client_user_agent = data.userAgent;
+
     const event: MetaConversionEvent = {
       event_name: 'ViewContent',
+      event_id: data.eventId,
       event_time: Math.floor(Date.now() / 1000),
       action_source: 'website',
-      user_data: {
-        ...getClientInfo()
-      },
+      user_data: userData,
       custom_data: {
-        content_type: contentType || 'website',
-        content_name: contentName || 'Homepage',
-        currency: 'CAD'
+        content_type: data.contentType || 'website',
+        content_name: data.contentName || 'Homepage',
+        currency: 'CAD',
+        ...(data.searchString ? { search_string: data.searchString } : {}),
       },
-      event_source_url: typeof window !== 'undefined' ? window.location.href : undefined
+      event_source_url: data.sourceUrl
+        || (typeof window !== 'undefined' ? window.location.href : undefined),
     };
 
     return this.sendEvent(event);
@@ -340,9 +357,17 @@ export function getMetaConversionAPI(): MetaConversionAPI | null {
 }
 
 // Convenience functions for tracking events
-export async function trackViewContent(contentName?: string, contentType?: string) {
+export async function trackViewContent(data: {
+  contentName?: string
+  contentType?: string
+  searchString?: string
+  eventId?: string
+  clientIp?: string
+  userAgent?: string
+  sourceUrl?: string
+} = {}) {
   if (metaAPI) {
-    return await metaAPI.trackViewContent(contentName, contentType);
+    return await metaAPI.trackViewContent(data);
   }
   console.warn('Meta Conversion API not initialized');
   return { success: false, error: 'API not initialized' };


### PR DESCRIPTION
> **Base = `feat/analysis-funnel-v2` (PAS `main`).** Cette PR Phase 2 et la PR #20 (Phase 1) seront mergées **ensemble dans `main`** à la fin.

## Summary

Phase 2 câble le backend du funnel `/analysis` V2 (isolation), **isolé** des autres funnels (thermopompes/subventions/soumission-rapide non touchés dans leur logique métier).

- **Pixel Meta dédié soumissionconfort** chargé uniquement sur `/analysis*` + `/verifier-telephone` (leads iso), via `<MetaPixelRouter />` qui utilise `fbq trackSingle` → garantit qu'**un seul pixel** reçoit chaque event. Garde-fou placeholder strict (pas de fallback).
- **ViewContent** fire au mount du wizard (browser `trackSingle` + CAPI dédupés via `eventID`), pixel dédié uniquement. Nouvel endpoint `app/api/meta/view-content/route.ts`.
- **Lead** fire uniquement si `intent=qualified` + OTP confirmé. Browser depuis `/verifier-telephone`, CAPI depuis `/api/leads` (gate intent + gate `isTest`). Dedup via `eventId`.
- **GHL** : écriture des 3 V2 fields (`symptoms`, `hydro_bracket`, `intent`) dans le sub-account Iso + **tag dynamique** `Lead Iso Hot` (qualifié) / `Lead Iso Curieux` (curieux). Override curieux→qualifié retire `Lead Iso Curieux` (DELETE `/tags`) ; qualifié→curieux **garde** `Lead Iso Hot` (décision 8). Tags gérés via POST/DELETE `/tags` (hors upsert, car l'upsert GHL **remplace** le tableau `tags`).
- **CompleteRegistration** retiré (`soumission-rapide/merci`).

## Review Codex intégrée (2 bugs critiques d'isolation trouvés + corrigés)

- **FIX #1** : `/verifier-telephone` est partagé entre 3 funnels → scopé via `otp-verify.source==='analysis'` pour que **seul un lead iso** charge le pixel dédié. Zéro contamination inter-funnel.
- **FIX #2** : tous les `fbq('track')` des autres funnels convertis en `trackSingle` ciblé sur le pixel partagé → un parcours croisé n'envoie **jamais** un Lead HVAC/subvention au pixel dédié iso.
- **FIX #5** : guard anti double-PageView (React StrictMode).

## Test plan

Validé en réel (Playwright + curl + GHL API + log serveur, vrai pixel dédié) :

- [x] **Lead qualifié** → CAPI Lead sur pixel `soumissionconfort` + GHL tag `Lead Iso Hot` + 3 V2 fields écrits
- [x] **Lead curieux** → `skip Meta CAPI Lead — intent !== qualified` + tag `Lead Iso Curieux`
- [x] **Override curieux→qualifié** → `Lead Iso Hot` ajouté, `Lead Iso Curieux` retiré (DELETE)
- [x] **Qualifié→curieux (décision 8)** → `['Lead Iso Hot', 'Lead Iso Curieux']` (Hot préservé)
- [x] **Garde-fou placeholder** → browser + serveur skip strict, aucune pollution
- [x] **Isolation /verifier-telephone** → lead HVAC/subvention reste sur le pixel partagé
- [x] **ViewContent CAPI** → `Meta Conversion API event sent: ViewContent` au pixel dédié
- [x] **DELETE /tags schema** `{tags:[...]}` confirmé (réponse `tagsRemoved`)
- [x] `npx tsc --noEmit` clean sur les 16 fichiers touchés
- [x] `grep CompleteRegistration` vide

**Hors-scope documenté** : `lib/meta-pixel.ts` est du code mort (aucun import). Finding Codex #3 (noscript path-blind) accepté — impact nul (no-JS n'atteint pas le wizard SPA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)