### PR TITLE
fix: corrige le domaine canonical .ai mort vers .com (SEO)

### DIFF
--- a/IMPLEMENTATION_GUIDE.md
+++ b/IMPLEMENTATION_GUIDE.md
@@ -754,7 +754,7 @@ vercel --prod
 - [Rénoclimat](https://www.transitionenergetique.gouv.qc.ca/residentiel/programmes/renoclimat)
 
 ### Contact
-- Email: support@soumissionconfort.ai
+- Email: support@soumissionconfort.com
 - Documentation interne: `/docs`
 
 ---

--- a/THERMOPOMPE_TRACKING_SETUP.md
+++ b/THERMOPOMPE_TRACKING_SETUP.md
@@ -59,7 +59,7 @@ if (isHVAC && successfulWebhooks > 0) {
         value: estimatedValue,
         clientIp,
         userAgent,
-        sourceUrl: `${request.headers.get('origin') || 'https://soumissionconfort.ai'}/thermopompes`,
+        sourceUrl: `${request.headers.get('origin') || 'https://soumissionconfort.com'}/thermopompes`,
         customData: {
           service_type: 'thermopompe'
         }

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -813,7 +813,7 @@ export async function POST(request: NextRequest) {
               const stdMax = leadData.pricingData?.ranges?.standard?.totalCost?.max || 0
               const estimatedValue = (stdMin + stdMax) / 2
 
-              const origin = request.headers.get('origin') || 'https://soumissionconfort.ai'
+              const origin = request.headers.get('origin') || 'https://soumissionconfort.com'
 
               console.log(`📊 LEADS API: Sending server-side Meta Lead event for isolation (eventId: ${leadData.eventId || 'none'}, dedicated pixel)`)
 

--- a/app/api/test-thermopompe/route.ts
+++ b/app/api/test-thermopompe/route.ts
@@ -54,7 +54,7 @@ export async function GET(request: NextRequest) {
       value: 15000,
       clientIp,
       userAgent,
-      sourceUrl: `${request.headers.get('origin') || 'https://soumissionconfort.ai'}/thermopompes`,
+      sourceUrl: `${request.headers.get('origin') || 'https://soumissionconfort.com'}/thermopompes`,
       customData: {
         service_type: 'thermopompe',
         test_event: true

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Soumission Confort - Estimation Gratuite d'Isolation d'Entretoit au Québec",
     description: "Obtenez votre estimation gratuite d'isolation d'entretoit en 60 secondes. Connectez-vous avec des entrepreneurs certifiés RBQ. Économisez jusqu'à 30% sur vos factures de chauffage. Subventions disponibles avec Hydro-Québec et RénoClimat.",
-    url: 'https://soumissionconfort.ai',
+    url: 'https://soumissionconfort.com',
     siteName: 'Soumission Confort',
     locale: 'fr_CA',
     type: 'website',
@@ -61,7 +61,7 @@ export default function RootLayout({
     "@type": "LocalBusiness",
     "name": "Soumission Confort",
     "description": "Estimation gratuite d'isolation d'entretoit au Québec. Entrepreneurs certifiés RBQ, subventions disponibles avec Hydro-Québec, LogisVert et RénoClimat.",
-    "url": "https://soumissionconfort.ai",
+    "url": "https://soumissionconfort.com",
     "telephone": "+1-800-CONFORT",
     "priceRange": "$$",
     "areaServed": [

--- a/app/pour-entrepreneurs/page.tsx
+++ b/app/pour-entrepreneurs/page.tsx
@@ -532,7 +532,7 @@ export default function PourEntrepreneursPage() {
               <div className="space-y-2 text-gray-400">
                 <div className="flex items-center space-x-2">
                   <Mail className="w-4 h-4" />
-                  <span>pro@soumissionconfort.ai</span>
+                  <span>pro@soumissionconfort.com</span>
                 </div>
                 <div className="flex items-center space-x-2">
                   <Phone className="w-4 h-4" />

--- a/app/soumission-rapide/[ville]/page.tsx
+++ b/app/soumission-rapide/[ville]/page.tsx
@@ -25,14 +25,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     openGraph: {
       title,
       description,
-      url: `https://soumissionconfort.ai/soumission-rapide/${ville}`,
+      url: `https://soumissionconfort.com/soumission-rapide/${ville}`,
       siteName: "Soumission Confort",
       locale: "fr_CA",
       type: "website",
     },
     robots: { index: true, follow: true },
     alternates: {
-      canonical: `https://soumissionconfort.ai/soumission-rapide/${ville}`,
+      canonical: `https://soumissionconfort.com/soumission-rapide/${ville}`,
     },
   }
 }
@@ -47,7 +47,7 @@ export default async function SoumissionRapidePage({ params }: PageProps) {
     "@type": "LocalBusiness",
     name: "Soumission Confort",
     description: `Service de soumission d'isolation gratuit à ${municipality.name}. Entrepreneurs certifiés RBQ, vérifiés et interviewés.`,
-    url: `https://soumissionconfort.ai/soumission-rapide/${ville}`,
+    url: `https://soumissionconfort.com/soumission-rapide/${ville}`,
     areaServed: {
       "@type": "City",
       name: municipality.name,

--- a/app/soumission-rapide/page.tsx
+++ b/app/soumission-rapide/page.tsx
@@ -9,14 +9,14 @@ export const metadata: Metadata = {
     title: "Soumission Isolation | 3 Soumissions Gratuites d'Entrepreneurs Certifiés au Québec",
     description:
       "Comparez 3 soumissions d'entrepreneurs en isolation certifiés RBQ au Québec. Service gratuit, entrepreneurs vérifiés et interviewés par notre équipe. Subventions disponibles. Réponse en moins de 48h.",
-    url: "https://soumissionconfort.ai/soumission-rapide",
+    url: "https://soumissionconfort.com/soumission-rapide",
     siteName: "Soumission Confort",
     locale: "fr_CA",
     type: "website",
   },
   robots: { index: true, follow: true },
   alternates: {
-    canonical: "https://soumissionconfort.ai/soumission-rapide",
+    canonical: "https://soumissionconfort.com/soumission-rapide",
   },
 }
 
@@ -27,7 +27,7 @@ export default function SoumissionRapidePage() {
     name: "Soumission Confort",
     description:
       "Service de soumission d'isolation gratuit au Québec. Entrepreneurs certifiés RBQ, vérifiés et interviewés.",
-    url: "https://soumissionconfort.ai/soumission-rapide",
+    url: "https://soumissionconfort.com/soumission-rapide",
     areaServed: {
       "@type": "State",
       name: "Québec",

--- a/lib/allowed-origins.ts
+++ b/lib/allowed-origins.ts
@@ -2,7 +2,6 @@ import type { NextRequest } from "next/server"
 
 const APEX_DOMAINS = [
   "soumissionconfort.com",
-  "soumissionconfort.ai",
 ] as const
 
 const PREVIEW_HOSTS = [

--- a/tests/lib/allowed-origins.test.ts
+++ b/tests/lib/allowed-origins.test.ts
@@ -25,8 +25,6 @@ describe("isAllowedOrigin — production hostnames", () => {
   it.each([
     "https://soumissionconfort.com",
     "https://www.soumissionconfort.com",
-    "https://soumissionconfort.ai",
-    "https://www.soumissionconfort.ai",
     "https://soumission-confort-ai.vercel.app",
   ])("allows %s", (origin) => {
     expect(isAllowedOrigin(makeRequest({ origin }))).toBe(true)
@@ -53,6 +51,8 @@ describe("isAllowedOrigin — denied origins", () => {
     "https://www.soumissionconfort.com.evil.io",
     "https://evil.vercel.app",
     "https://soumissionconfort-evil.com",
+    "https://soumissionconfort.ai",
+    "https://www.soumissionconfort.ai",
   ])("denies %s", (origin) => {
     expect(isAllowedOrigin(makeRequest({ origin }))).toBe(false)
   })


### PR DESCRIPTION
## Summary

- Le site tourne en prod sur **soumissionconfort.com** mais le code pointait vers **soumissionconfort.ai** (domaine mort, DNS ne résout pas — hérité d'un copier-coller de Soumission Toiture).
- **13 références `.ai` → `.com`** : 8 SEO (canonical / Open Graph / JSON-LD), 2 fallbacks d'origine API, 1 retrait du whitelist CORS (+ test ajusté), 1 email de contact (`pro@`).
- **Problème réglé** : les `canonical` pointaient vers une URL morte → signal négatif pour Google sur un site qui carbure au SEO local (40 villes pSEO). Tout pointe maintenant vers le vrai domaine.

**Hors-scope (non touché) :** le slug Vercel `soumission-confort-ai.vercel.app` (nom de déploiement, pas le domaine `.ai`).

## Test plan

- `grep` de contrôle : 0 occurrence `.ai` restante (sauf les 2 cas de test qui vérifient maintenant que `.ai` est **refusé**, et le slug Vercel).
- `npx tsc --noEmit` : 0 nouvelle erreur sur les 8 fichiers (59 préexistantes, sans rapport).
- `vitest run tests/lib/allowed-origins.test.ts` : **17/17 passent** — les 2 nouveaux cas confirment que `soumissionconfort.ai` et `www.soumissionconfort.ai` sont désormais bloqués par le CORS.
- Après merge + déploiement : vérifier en prod (View Source / Google Search Console) que les `canonical` pointent vers `.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)