### PR TITLE
fix(meta-pixel): 1 seul PageView à l'entrée + dédup Lead durcie (pixel 1508005413751111)

### DIFF
--- a/app/verifier-telephone/page.tsx
+++ b/app/verifier-telephone/page.tsx
@@ -200,19 +200,23 @@ export default function VerifierTelephonePage() {
           const pending = JSON.parse(pendingRaw)
           if (
             pending?.meta?.intent === "qualified" &&
+            typeof pending.eventId === "string" &&
+            pending.eventId &&
             typeof window !== "undefined" &&
             typeof window.fbq === "function" &&
             META_PIXEL_DEDIE &&
             !/^X+$/i.test(META_PIXEL_DEDIE)
           ) {
-            const leadEventId =
-              pending.eventId ||
-              ("randomUUID" in crypto ? crypto.randomUUID() : `lead-${Date.now()}`)
+            // Fire the browser Lead with the SAME eventId the CAPI Lead
+            // (/api/leads) uses → Meta dedups browser↔CAPI to ONE Lead. A fresh
+            // random id would NOT match the CAPI id and double-count. If eventId
+            // is missing (corrupt/stale sessionStorage), skip the browser pixel:
+            // the CAPI Lead still fires → counted once, never dropped.
             window.fbq("trackSingle", META_PIXEL_DEDIE, "Lead", {
               value: Number(pending.meta.estimatedValue || 0).toFixed(2),
               currency: "CAD",
               service_type: "isolation",
-            }, { eventID: leadEventId })
+            }, { eventID: pending.eventId })
           }
         }
       } catch (err) {

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -7,12 +7,20 @@ import { usePathname } from 'next/navigation'
 // Phase 2 V2 — route-aware Meta Pixel loader.
 //
 // One <MetaPixelRouter /> is mounted once in app/layout.tsx. It guarantees the
-// invariant: a PageView fires to EXACTLY ONE pixel per route, and the dedicated
-// soumissionconfort pixel ONLY ever sees the isolation /analysis funnel.
-//   - /analysis*                          → dedicated pixel
-//   - /pricing                            → dedicated pixel (iso results page)
-//   - /verifier-telephone (analysis only) → dedicated pixel
-//   - everything else                     → shared Niku pixel (status quo)
+// invariant: the dedicated soumissionconfort pixel ONLY ever sees the isolation
+// funnel, and a PageView fires EXACTLY ONCE — on the home entry point '/'.
+//   - '/' (home, address entry)           → dedicated pixel: INIT + PageView
+//   - /analysis*                          → dedicated pixel: INIT only (no PageView)
+//   - /pricing                            → dedicated pixel: INIT only (no PageView)
+//   - /verifier-telephone (analysis only) → dedicated pixel: INIT only (no PageView)
+//   - everything else                     → shared Niku pixel (status quo, '')
+//
+// Why the funnel routes still INIT (but don't PageView): the wizard ViewContent
+// (user-questionnaire-wizard.tsx) and the post-OTP Lead (verifier-telephone/
+// page.tsx) call fbq('trackSingle', META_PIXEL_DEDIE, ...) directly and need an
+// initialised pixel. They emit NO PageView — Zack wants ONE PageView (the home
+// arrival), not one per SPA route. So PageView is gated to the entry point '/',
+// while init runs on every dedicated-pixel route.
 //
 // /pricing is the isolation results page (InsulationResults). It's reached ONLY
 // from the analysis lead form (lead-capture-form.tsx redirects there post-OTP),
@@ -62,6 +70,15 @@ export function isAnalysisWizardRoute(pathname: string): boolean {
     || pathname === '/pricing'
 }
 
+// '/' (home iso) is the single Meta PageView entry point — the page with the
+// address field, where the visitor "arrives". It's NOT part of the bottom
+// funnel (no wizard, no lead form) so it's classified separately from
+// inAnalysisFunnelClient: PageView fires here and ONLY here, while the funnel
+// routes init the pixel without emitting a PageView.
+export function isPixelEntryPoint(pathname: string): boolean {
+  return pathname === '/'
+}
+
 // Reads the OTP source marker the analysis lead form stamps in sessionStorage.
 // Only meaningful on /verifier-telephone, and only client-side.
 function otpSourceIsAnalysis(): boolean {
@@ -93,11 +110,17 @@ export function MetaPixelRouter() {
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.fbq !== 'function') return
 
+    // The dedicated pixel must be INITIALISED on BOTH the entry point ('/') and
+    // the funnel routes — the funnel routes need it live so the wizard
+    // ViewContent and post-OTP Lead (which target META_PIXEL_DEDIE directly)
+    // land on an initialised pixel. PageView, however, fires on '/' ONLY.
+    const isEntry = isPixelEntryPoint(pathname)
     const inFunnel = inAnalysisFunnelClient(pathname)
-    // Strict guard (Zack v2 décision 5): on the /analysis funnel, if the
-    // dedicated pixel is missing/placeholder, fire NOTHING — never leak the
-    // funnel onto the shared pixel during rollout.
-    const pixelForRoute = inFunnel ? META_PIXEL_DEDIE : PIXEL_PARTAGE
+    const needsDedicated = isEntry || inFunnel
+    // Strict guard (Zack v2 décision 5): on any dedicated-pixel route, if the
+    // pixel is missing/placeholder, fire NOTHING — never leak onto the shared
+    // pixel during rollout.
+    const pixelForRoute = needsDedicated ? META_PIXEL_DEDIE : PIXEL_PARTAGE
     if (isPlaceholder(pixelForRoute)) return
 
     // Init this pixel once (idempotent across navigations).
@@ -110,6 +133,11 @@ export function MetaPixelRouter() {
       window.fbq('init', pixelForRoute)
       initedRef.current.add(pixelForRoute)
     }
+
+    // PageView fires ONLY on the entry point ('/'). The funnel routes init the
+    // pixel above but emit no PageView (Zack wants exactly ONE PageView, on the
+    // home page — not one per SPA route).
+    if (!isEntry) return
 
     // Fire PageView to THIS pixel only — never the other one. The dedupe key
     // pins it to (pixel, pathname) so StrictMode's double effect doesn't send

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -8,8 +8,12 @@ import { usePathname } from 'next/navigation'
 //
 // One <MetaPixelRouter /> is mounted once in app/layout.tsx. It guarantees the
 // invariant: the dedicated soumissionconfort pixel ONLY ever sees the isolation
-// funnel, and a PageView fires EXACTLY ONCE per session — owed by the FIRST
-// dedicated-pixel route the visitor hits (the funnel entry), then flushed once.
+// funnel, and a PageView fires EXACTLY ONCE per page load (SPA mount) — owed by
+// the FIRST dedicated-pixel route the visitor hits (the funnel entry), then
+// flushed once. A genuine document reload (F5) is a new page load and fires a
+// fresh PageView — that's standard Meta behaviour, not a duplicate; the
+// fired-flag only dedups within a single SPA mount (StrictMode, re-renders, and
+// all client-side navigations).
 //   - '/' (home, address entry)           → dedicated pixel: INIT, owes the PageView
 //   - /analysis*                          → dedicated pixel: INIT (owes it if entered here)
 //   - /pricing                            → dedicated pixel: INIT (owes it if entered here)

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -23,12 +23,16 @@ import { usePathname } from 'next/navigation'
 // The PageView is tied to the funnel VISIT, not to a single route: the first
 // dedicated route owes it (so a visitor entering via '/', a deep-link to
 // /analysis, or a Toiture landing page that pushes into /analysis all get
-// exactly one), and it's flushed as soon as fbq is live — on whatever route the
-// visitor is on by then. Normal flow: '/' owes it and it fires on '/'. Once
+// exactly one), and it's flushed as soon as fbq is live — but ONLY while on a
+// dedicated route (the flush is behind the dedicated-pixel guard). If the
+// visitor bounces to a shared/non-funnel page before fbq boots, the owed
+// PageView is dropped rather than stamped with a non-funnel URL — isolation
+// wins over completeness. Normal flow: '/' owes it and it fires on '/'. Once
 // fired, no route fires another. Two things make this exact:
 //   1. disablePushState — fbevents auto-fires a PageView on every history
-//      pushState (SPA nav) by default; we turn that off and emit the one
-//      PageView ourselves, so route changes add nothing.
+//      pushState (SPA nav) by default; we set fbq.disablePushState=true in the
+//      bootstrap <Script> BEFORE fbevents loads (so its listener never installs)
+//      and emit the one PageView ourselves, so route changes add nothing.
 //   2. the fired-flag debt — survives a fast nav before fbq boots and dedups
 //      StrictMode / re-renders, so it's never lost and never duplicated.
 // The funnel routes still INIT regardless because the wizard ViewContent
@@ -144,21 +148,15 @@ export function MetaPixelRouter() {
 
     if (typeof window === 'undefined' || typeof window.fbq !== 'function') return
 
-    // Disable fbevents' automatic PageView on SPA history pushState. By default
-    // the library fires a PageView on EVERY history.pushState (every client
-    // route change), which would re-add one PageView per funnel route —
-    // precisely what this change removes. We own the single PageView explicitly
-    // (funnel debt, below), so the automatic one must be off. Set before the
-    // first fbq('init'). Ref: https://developers.facebook.com/docs/meta-pixel/get-started/
-    const fbqWithFlags = window.fbq as unknown as { disablePushState?: boolean }
-    fbqWithFlags.disablePushState = true
-
-    // The dedicated pixel must be live on dedicated routes (the wizard
-    // ViewContent + post-OTP Lead target META_PIXEL_DEDIE directly), AND on any
-    // route while we still owe the PageView (so it can flush even after the
-    // visitor left the route that owed it). Everything else → PIXEL_PARTAGE ('').
-    const needsDedicated = onDedicatedRoute || funnelPageViewPendingRef.current
-    const pixelForRoute = needsDedicated ? META_PIXEL_DEDIE : PIXEL_PARTAGE
+    // Only dedicated routes load the dedicated pixel. We deliberately do NOT add
+    // the pending debt to this condition: the owed PageView must flush on a
+    // dedicated route, NEVER on a shared/non-funnel page the visitor bounced to
+    // before fbq booted — firing there would stamp a non-funnel
+    // event_source_url onto the dedicated pixel (isolation leak). If the visitor
+    // leaves the funnel before fbq is live, the owed PageView is simply not
+    // fired — correct, they didn't meaningfully enter. (disablePushState is set
+    // in the bootstrap <Script> below, before fbevents loads its listener.)
+    const pixelForRoute = onDedicatedRoute ? META_PIXEL_DEDIE : PIXEL_PARTAGE
     // Strict guard (Zack v2 décision 5): if the dedicated pixel is missing/
     // placeholder, fire NOTHING — never leak onto the shared pixel.
     if (isPlaceholder(pixelForRoute)) return
@@ -173,8 +171,8 @@ export function MetaPixelRouter() {
     }
 
     // Flush the owed funnel-entry PageView EXACTLY ONCE, as soon as fbq is live.
-    // It fires on whatever route the visitor is on now (covers the cold-load
-    // race where fbq boots after they left the entry route). The fired-flag
+    // We only reach here on a dedicated route (guard above), so the PageView is
+    // always stamped with a funnel URL — never a shared page. The fired-flag
     // guarantees exactly-once across StrictMode / re-renders / SPA nav.
     if (funnelPageViewPendingRef.current && !funnelPageViewFiredRef.current) {
       funnelPageViewFiredRef.current = true
@@ -198,6 +196,7 @@ export function MetaPixelRouter() {
           n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
           t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
           document,'script','https://connect.facebook.net/en_US/fbevents.js');
+          window.fbq.disablePushState = true;
         `}
       </Script>
       {/* noscript fallback uses the shared pixel — the no-JS case never reaches

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Script from 'next/script'
 import { usePathname } from 'next/navigation'
 
@@ -106,6 +106,13 @@ export function MetaPixelRouter() {
   const initedRef = useRef<Set<string>>(new Set())
   // Guard against StrictMode double-effect / duplicate PageView per route.
   const lastPageViewRef = useRef<string | null>(null)
+  // fbq is bootstrapped by an afterInteractive <Script> that may execute AFTER
+  // this effect's first run. With dep [pathname] alone the effect would never
+  // re-run on the home route, so a fbq-not-ready-yet first paint would silently
+  // MISS the home PageView. onReady flips this flag → the effect re-runs once
+  // fbq is live. (Race is pre-existing, but now load-bearing: '/' is the only
+  // route that fires PageView, and it's the cold-load route.)
+  const [fbqReady, setFbqReady] = useState(false)
 
   useEffect(() => {
     if (typeof window === 'undefined' || typeof window.fbq !== 'function') return
@@ -147,7 +154,7 @@ export function MetaPixelRouter() {
       lastPageViewRef.current = pageViewKey
       window.fbq('trackSingle', pixelForRoute, 'PageView')
     }
-  }, [pathname])
+  }, [pathname, fbqReady])
 
   // The bootstrap snippet loads the fbq library exactly once for the whole
   // app. We deliberately do NOT call fbq('init'/'track') inside it — the
@@ -157,7 +164,7 @@ export function MetaPixelRouter() {
 
   return (
     <>
-      <Script id="meta-pixel-bootstrap" strategy="afterInteractive">
+      <Script id="meta-pixel-bootstrap" strategy="afterInteractive" onReady={() => setFbqReady(true)}>
         {`
           !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
           n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -8,22 +8,28 @@ import { usePathname } from 'next/navigation'
 //
 // One <MetaPixelRouter /> is mounted once in app/layout.tsx. It guarantees the
 // invariant: the dedicated soumissionconfort pixel ONLY ever sees the isolation
-// funnel, and a PageView fires EXACTLY ONCE — owed by the home entry '/'.
-//   - '/' (home, address entry)           → dedicated pixel: INIT + owes PageView
-//   - /analysis*                          → dedicated pixel: INIT only (no new PageView)
-//   - /pricing                            → dedicated pixel: INIT only (no new PageView)
-//   - /verifier-telephone (analysis only) → dedicated pixel: INIT only (no new PageView)
+// funnel, and a PageView fires EXACTLY ONCE per session — owed by the FIRST
+// dedicated-pixel route the visitor hits (the funnel entry), then flushed once.
+//   - '/' (home, address entry)           → dedicated pixel: INIT, owes the PageView
+//   - /analysis*                          → dedicated pixel: INIT (owes it if entered here)
+//   - /pricing                            → dedicated pixel: INIT (owes it if entered here)
+//   - /verifier-telephone (analysis only) → dedicated pixel: INIT (owes it if entered here)
 //   - everything else                     → shared Niku pixel (status quo, '')
 //
-// Why the funnel routes still INIT: the wizard ViewContent (user-questionnaire-
-// wizard.tsx) and the post-OTP Lead (verifier-telephone/page.tsx) call
-// fbq('trackSingle', META_PIXEL_DEDIE, ...) directly and need an initialised
-// pixel. Zack wants ONE PageView (the home arrival), not one per SPA route — so
-// the home visit OWES a single PageView, flushed as soon as fbq is live,
-// regardless of the route the visitor is on by then. Normal case: fbq is ready
-// on '/' and it fires there. Cold-load race (fbq boots after a fast '/' →
-// '/analysis' nav): it flushes on the next route instead — still exactly once,
-// never lost, never duplicated.
+// The PageView is tied to the funnel VISIT, not to a single route: the first
+// dedicated route owes it (so a visitor entering via '/', a deep-link to
+// /analysis, or a Toiture landing page that pushes into /analysis all get
+// exactly one), and it's flushed as soon as fbq is live — on whatever route the
+// visitor is on by then. Normal flow: '/' owes it and it fires on '/'. Once
+// fired, no route fires another. Two things make this exact:
+//   1. disablePushState — fbevents auto-fires a PageView on every history
+//      pushState (SPA nav) by default; we turn that off and emit the one
+//      PageView ourselves, so route changes add nothing.
+//   2. the fired-flag debt — survives a fast nav before fbq boots and dedups
+//      StrictMode / re-renders, so it's never lost and never duplicated.
+// The funnel routes still INIT regardless because the wizard ViewContent
+// (user-questionnaire-wizard.tsx) and post-OTP Lead (verifier-telephone/
+// page.tsx) call fbq('trackSingle', META_PIXEL_DEDIE, ...) directly.
 //
 // /pricing is the isolation results page (InsulationResults). It's reached ONLY
 // from the analysis lead form (lead-capture-form.tsx redirects there post-OTP),
@@ -107,25 +113,29 @@ export function MetaPixelRouter() {
   const pathname = usePathname()
   // Track which pixels we've already `init`-ed so we never double-init.
   const initedRef = useRef<Set<string>>(new Set())
-  // The home '/' entry owes EXACTLY ONE PageView. We capture it as a pending
-  // debt the moment we see '/', then flush it as soon as fbq is live — even if
-  // the visitor has already navigated away from '/'. This is what makes the
-  // single PageView survive a fast '/' → '/analysis' nav before fbq booted: the
-  // event is owed to the home VISIT, not to the pathname at fbq-ready time.
-  const homePageViewPendingRef = useRef(false)
-  const homePageViewFiredRef = useRef(false)
+  // The isolation funnel owes EXACTLY ONE PageView, captured as a debt the first
+  // time the visitor hits ANY dedicated-pixel route — the home '/', a deep-link
+  // to /analysis, or a landing page (e.g. /urgence-toiture, /couvreur-shawinigan)
+  // that pushes into /analysis. It's flushed once, as soon as fbq is live, even
+  // if the visitor navigated on before fbq booted. Tying it to the funnel VISIT
+  // (not the pathname at fbq-ready time) is what keeps it exactly-once and never
+  // lost. Non-funnel routes never set the debt → never fire a PageView.
+  const funnelPageViewPendingRef = useRef(false)
+  const funnelPageViewFiredRef = useRef(false)
   // fbq is bootstrapped by an afterInteractive <Script> that may execute AFTER
   // this effect's first run. onReady flips this flag → the effect re-runs once
-  // fbq is live so the owed home PageView can flush. ('/' is the only route
-  // that emits PageView and it's the cold-load route, so this must be robust.)
+  // fbq is live so the owed PageView can flush (the cold-load route is exactly
+  // where fbq is least likely to be ready in time, so this must be robust).
   const [fbqReady, setFbqReady] = useState(false)
 
   useEffect(() => {
-    // Capture the home-entry PageView debt the moment we see '/', regardless of
-    // fbq readiness (pure check, no window needed). It survives navigation away
-    // from '/', so a visitor who leaves before fbq boots still gets the event.
-    if (isPixelEntryPoint(pathname) && !homePageViewFiredRef.current) {
-      homePageViewPendingRef.current = true
+    // Capture the funnel-entry PageView debt the moment we land on any
+    // dedicated-pixel route, regardless of fbq readiness (pure check, no window
+    // needed). It survives navigation away, so a visitor who leaves before fbq
+    // boots still gets exactly one PageView.
+    const onDedicatedRoute = isPixelEntryPoint(pathname) || inAnalysisFunnelClient(pathname)
+    if (onDedicatedRoute && !funnelPageViewFiredRef.current) {
+      funnelPageViewPendingRef.current = true
     }
 
     if (typeof window === 'undefined' || typeof window.fbq !== 'function') return
@@ -134,17 +144,16 @@ export function MetaPixelRouter() {
     // the library fires a PageView on EVERY history.pushState (every client
     // route change), which would re-add one PageView per funnel route —
     // precisely what this change removes. We own the single PageView explicitly
-    // (home debt, below), so the automatic one must be off. Set before the first
-    // fbq('init'). Ref: https://developers.facebook.com/docs/meta-pixel/get-started/
+    // (funnel debt, below), so the automatic one must be off. Set before the
+    // first fbq('init'). Ref: https://developers.facebook.com/docs/meta-pixel/get-started/
     const fbqWithFlags = window.fbq as unknown as { disablePushState?: boolean }
     fbqWithFlags.disablePushState = true
 
-    const inFunnel = inAnalysisFunnelClient(pathname)
-    // Routes that need the dedicated pixel live: the funnel routes (the wizard
-    // ViewContent + post-OTP Lead target META_PIXEL_DEDIE directly), PLUS any
-    // route where we still owe the home PageView (so it can flush even after the
-    // visitor left '/'). Everything else falls to PIXEL_PARTAGE ('') = no-op.
-    const needsDedicated = inFunnel || homePageViewPendingRef.current
+    // The dedicated pixel must be live on dedicated routes (the wizard
+    // ViewContent + post-OTP Lead target META_PIXEL_DEDIE directly), AND on any
+    // route while we still owe the PageView (so it can flush even after the
+    // visitor left the route that owed it). Everything else → PIXEL_PARTAGE ('').
+    const needsDedicated = onDedicatedRoute || funnelPageViewPendingRef.current
     const pixelForRoute = needsDedicated ? META_PIXEL_DEDIE : PIXEL_PARTAGE
     // Strict guard (Zack v2 décision 5): if the dedicated pixel is missing/
     // placeholder, fire NOTHING — never leak onto the shared pixel.
@@ -159,14 +168,13 @@ export function MetaPixelRouter() {
       initedRef.current.add(pixelForRoute)
     }
 
-    // Flush the owed home PageView EXACTLY ONCE, as soon as fbq is live. It
-    // fires on whatever route the visitor is on now (covers the cold-load race
-    // where fbq boots after they left '/'). The fired-flag guarantees
-    // exactly-once across StrictMode / re-renders / SPA nav; no other route ever
-    // emits a PageView.
-    if (homePageViewPendingRef.current && !homePageViewFiredRef.current) {
-      homePageViewFiredRef.current = true
-      homePageViewPendingRef.current = false
+    // Flush the owed funnel-entry PageView EXACTLY ONCE, as soon as fbq is live.
+    // It fires on whatever route the visitor is on now (covers the cold-load
+    // race where fbq boots after they left the entry route). The fired-flag
+    // guarantees exactly-once across StrictMode / re-renders / SPA nav.
+    if (funnelPageViewPendingRef.current && !funnelPageViewFiredRef.current) {
+      funnelPageViewFiredRef.current = true
+      funnelPageViewPendingRef.current = false
       window.fbq('trackSingle', META_PIXEL_DEDIE, 'PageView')
     }
   }, [pathname, fbqReady])

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -8,19 +8,22 @@ import { usePathname } from 'next/navigation'
 //
 // One <MetaPixelRouter /> is mounted once in app/layout.tsx. It guarantees the
 // invariant: the dedicated soumissionconfort pixel ONLY ever sees the isolation
-// funnel, and a PageView fires EXACTLY ONCE — on the home entry point '/'.
-//   - '/' (home, address entry)           → dedicated pixel: INIT + PageView
-//   - /analysis*                          → dedicated pixel: INIT only (no PageView)
-//   - /pricing                            → dedicated pixel: INIT only (no PageView)
-//   - /verifier-telephone (analysis only) → dedicated pixel: INIT only (no PageView)
+// funnel, and a PageView fires EXACTLY ONCE — owed by the home entry '/'.
+//   - '/' (home, address entry)           → dedicated pixel: INIT + owes PageView
+//   - /analysis*                          → dedicated pixel: INIT only (no new PageView)
+//   - /pricing                            → dedicated pixel: INIT only (no new PageView)
+//   - /verifier-telephone (analysis only) → dedicated pixel: INIT only (no new PageView)
 //   - everything else                     → shared Niku pixel (status quo, '')
 //
-// Why the funnel routes still INIT (but don't PageView): the wizard ViewContent
-// (user-questionnaire-wizard.tsx) and the post-OTP Lead (verifier-telephone/
-// page.tsx) call fbq('trackSingle', META_PIXEL_DEDIE, ...) directly and need an
-// initialised pixel. They emit NO PageView — Zack wants ONE PageView (the home
-// arrival), not one per SPA route. So PageView is gated to the entry point '/',
-// while init runs on every dedicated-pixel route.
+// Why the funnel routes still INIT: the wizard ViewContent (user-questionnaire-
+// wizard.tsx) and the post-OTP Lead (verifier-telephone/page.tsx) call
+// fbq('trackSingle', META_PIXEL_DEDIE, ...) directly and need an initialised
+// pixel. Zack wants ONE PageView (the home arrival), not one per SPA route — so
+// the home visit OWES a single PageView, flushed as soon as fbq is live,
+// regardless of the route the visitor is on by then. Normal case: fbq is ready
+// on '/' and it fires there. Cold-load race (fbq boots after a fast '/' →
+// '/analysis' nav): it flushes on the next route instead — still exactly once,
+// never lost, never duplicated.
 //
 // /pricing is the isolation results page (InsulationResults). It's reached ONLY
 // from the analysis lead form (lead-capture-form.tsx redirects there post-OTP),
@@ -104,55 +107,67 @@ export function MetaPixelRouter() {
   const pathname = usePathname()
   // Track which pixels we've already `init`-ed so we never double-init.
   const initedRef = useRef<Set<string>>(new Set())
-  // Guard against StrictMode double-effect / duplicate PageView per route.
-  const lastPageViewRef = useRef<string | null>(null)
+  // The home '/' entry owes EXACTLY ONE PageView. We capture it as a pending
+  // debt the moment we see '/', then flush it as soon as fbq is live — even if
+  // the visitor has already navigated away from '/'. This is what makes the
+  // single PageView survive a fast '/' → '/analysis' nav before fbq booted: the
+  // event is owed to the home VISIT, not to the pathname at fbq-ready time.
+  const homePageViewPendingRef = useRef(false)
+  const homePageViewFiredRef = useRef(false)
   // fbq is bootstrapped by an afterInteractive <Script> that may execute AFTER
-  // this effect's first run. With dep [pathname] alone the effect would never
-  // re-run on the home route, so a fbq-not-ready-yet first paint would silently
-  // MISS the home PageView. onReady flips this flag → the effect re-runs once
-  // fbq is live. (Race is pre-existing, but now load-bearing: '/' is the only
-  // route that fires PageView, and it's the cold-load route.)
+  // this effect's first run. onReady flips this flag → the effect re-runs once
+  // fbq is live so the owed home PageView can flush. ('/' is the only route
+  // that emits PageView and it's the cold-load route, so this must be robust.)
   const [fbqReady, setFbqReady] = useState(false)
 
   useEffect(() => {
+    // Capture the home-entry PageView debt the moment we see '/', regardless of
+    // fbq readiness (pure check, no window needed). It survives navigation away
+    // from '/', so a visitor who leaves before fbq boots still gets the event.
+    if (isPixelEntryPoint(pathname) && !homePageViewFiredRef.current) {
+      homePageViewPendingRef.current = true
+    }
+
     if (typeof window === 'undefined' || typeof window.fbq !== 'function') return
 
-    // The dedicated pixel must be INITIALISED on BOTH the entry point ('/') and
-    // the funnel routes — the funnel routes need it live so the wizard
-    // ViewContent and post-OTP Lead (which target META_PIXEL_DEDIE directly)
-    // land on an initialised pixel. PageView, however, fires on '/' ONLY.
-    const isEntry = isPixelEntryPoint(pathname)
+    // Disable fbevents' automatic PageView on SPA history pushState. By default
+    // the library fires a PageView on EVERY history.pushState (every client
+    // route change), which would re-add one PageView per funnel route —
+    // precisely what this change removes. We own the single PageView explicitly
+    // (home debt, below), so the automatic one must be off. Set before the first
+    // fbq('init'). Ref: https://developers.facebook.com/docs/meta-pixel/get-started/
+    const fbqWithFlags = window.fbq as unknown as { disablePushState?: boolean }
+    fbqWithFlags.disablePushState = true
+
     const inFunnel = inAnalysisFunnelClient(pathname)
-    const needsDedicated = isEntry || inFunnel
-    // Strict guard (Zack v2 décision 5): on any dedicated-pixel route, if the
-    // pixel is missing/placeholder, fire NOTHING — never leak onto the shared
-    // pixel during rollout.
+    // Routes that need the dedicated pixel live: the funnel routes (the wizard
+    // ViewContent + post-OTP Lead target META_PIXEL_DEDIE directly), PLUS any
+    // route where we still owe the home PageView (so it can flush even after the
+    // visitor left '/'). Everything else falls to PIXEL_PARTAGE ('') = no-op.
+    const needsDedicated = inFunnel || homePageViewPendingRef.current
     const pixelForRoute = needsDedicated ? META_PIXEL_DEDIE : PIXEL_PARTAGE
+    // Strict guard (Zack v2 décision 5): if the dedicated pixel is missing/
+    // placeholder, fire NOTHING — never leak onto the shared pixel.
     if (isPlaceholder(pixelForRoute)) return
 
-    // Init this pixel once (idempotent across navigations).
+    // Init once (idempotent). Disable Meta's auto-event detection BEFORE init so
+    // no `SubscribedButtonClick`-style auto events leak — we fire only what we
+    // emit explicitly.
     if (!initedRef.current.has(pixelForRoute)) {
-      // Disable Meta's automatic event detection (button/form clicks etc.) for
-      // this pixel — we only want the events we fire explicitly. Without this,
-      // the pixel emits auto events like `SubscribedButtonClick`. Set BEFORE
-      // init so it applies from the first event.
       window.fbq('set', 'autoConfig', false, pixelForRoute)
       window.fbq('init', pixelForRoute)
       initedRef.current.add(pixelForRoute)
     }
 
-    // PageView fires ONLY on the entry point ('/'). The funnel routes init the
-    // pixel above but emit no PageView (Zack wants exactly ONE PageView, on the
-    // home page — not one per SPA route).
-    if (!isEntry) return
-
-    // Fire PageView to THIS pixel only — never the other one. The dedupe key
-    // pins it to (pixel, pathname) so StrictMode's double effect doesn't send
-    // two PageViews for the same route in dev.
-    const pageViewKey = `${pixelForRoute}:${pathname}`
-    if (lastPageViewRef.current !== pageViewKey) {
-      lastPageViewRef.current = pageViewKey
-      window.fbq('trackSingle', pixelForRoute, 'PageView')
+    // Flush the owed home PageView EXACTLY ONCE, as soon as fbq is live. It
+    // fires on whatever route the visitor is on now (covers the cold-load race
+    // where fbq boots after they left '/'). The fired-flag guarantees
+    // exactly-once across StrictMode / re-renders / SPA nav; no other route ever
+    // emits a PageView.
+    if (homePageViewPendingRef.current && !homePageViewFiredRef.current) {
+      homePageViewFiredRef.current = true
+      homePageViewPendingRef.current = false
+      window.fbq('trackSingle', META_PIXEL_DEDIE, 'PageView')
     }
   }, [pathname, fbqReady])
 


### PR DESCRIPTION
## Objectif

Pixel Meta dédié \`1508005413751111\` (funnel estimateur rapide isolation) : fire **exactement 3 events standard** sur un parcours, et rien d'autre :
1. **PageView** — une seule fois, à l'entrée du funnel.
2. **ViewContent** — une seule fois, à la 1ère question (déjà correct, non modifié).
3. **Lead** — post-OTP après confirmation du numéro (timing déjà correct, dédup durcie).

Avant : le pixel firait un PageView **par route SPA** + un PageView **auto sur chaque pushState** (fbevents) → plusieurs PageViews par session.

## Commits (6)

1. **PageView une fois à l'entrée** — `isPixelEntryPoint` + découplage init/PageView dans le router.
2. **Dédup Lead** — le browser Lead n'utilise plus de fallback `randomUUID` ; il fire avec le même `eventId` que le CAPI (ou skip, le CAPI couvre) → jamais de double-compte, jamais perdu.
3. **Race fbq-readiness** — `onReady` + retrigger pour ne pas manquer le PageView si `fbq` boote tard.
4. **Réponse Codex (round 1)** — PageView en **dette** (capturée puis flushée quand `fbq` live, indépendant du pathname) + **`fbq.disablePushState=true`** pour tuer le PageView auto de fbevents sur chaque navigation SPA.
5. **Réponse Codex (round 2)** — la dette est owed sur la **1ère route dédiée** (`/` OU `/analysis`…), donc les entrées hors-`/` (deep-link `/analysis`, landings `/urgence-toiture`/`/couvreur-shawinigan` → `/analysis`) firent aussi exactement 1 PageView.
6. **Doc** — invariant précisé : exactly-once **par page load (SPA mount)** ; un reload = nouveau PageView (standard Meta).

Diff : `components/meta-pixel-router.tsx` + `app/verifier-telephone/page.tsx`. ViewContent, Lead CAPI, source eventId **non touchés**.

## Vérification

- **Workflow adversarial 7 agents** → GO.
- **Codex adversarial review ×3** : 2 findings [high] trouvés (PageView perdu sur race ; PageView=0 sur entrées hors-`/`) → **corrigés et re-vérifiés**. Round 3 : point de formulation (reload = nouveau PageView), by-design.
- **Runtime (Playwright, capture `facebook.com/tr`) :**

| Parcours | Attendu | Observé |
|---|---|---|
| `/` (cold load) | 1 PageView | ✅ 1 (`dl=/`) |
| SPA `/` → `/analysis` (via CTA) | 1 PageView (sur `/`) + 1 ViewContent, pas de 2e PageView | ✅ |
| deep-link `/analysis` | 1 PageView (`dl=/analysis`) + 1 ViewContent | ✅ |
| `/pricing`, `/success` | rien | ✅ |
| `/urgence-toiture` (route non-funnel) | rien | ✅ 0 |
| `window.fbq.disablePushState` | true | ✅ true |

> **Lead post-OTP** : vérifié statiquement (dédup browser↔CAPI via eventId, timing intact). Non testé en runtime pour ne pas créer de vrai lead prod.

## Suivis non-bloquants
- `lib/meta-pixel.ts` = code mort (0 importeur) — à supprimer.
- Ajouter un test du gate (1 PageView par entrée funnel, 0 ailleurs).
- ⚠️ Copy ancien-modèle sur la home (« 150+ entrepreneurs », « 3 soumissions ») — hors scope pixel, à traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)