### PR TITLE
fix: point apex domain references to www

### DIFF
--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -322,7 +322,7 @@ export async function POST(request: NextRequest) {
               const stdMin = leadData.pricingData?.ranges?.standard?.totalCost?.min || 0
               const stdMax = leadData.pricingData?.ranges?.standard?.totalCost?.max || 0
               const estimatedValue = (stdMin + stdMax) / 2
-              const origin = request.headers.get('origin') || 'https://soumissionconfort.com'
+              const origin = request.headers.get('origin') || 'https://www.soumissionconfort.com'
               await metaAPI.trackLead({
                 email: leadData.email,
                 phone: leadData.phone,
@@ -813,7 +813,7 @@ export async function POST(request: NextRequest) {
               const stdMax = leadData.pricingData?.ranges?.standard?.totalCost?.max || 0
               const estimatedValue = (stdMin + stdMax) / 2
 
-              const origin = request.headers.get('origin') || 'https://soumissionconfort.com'
+              const origin = request.headers.get('origin') || 'https://www.soumissionconfort.com'
 
               console.log(`📊 LEADS API: Sending server-side Meta Lead event for isolation (eventId: ${leadData.eventId || 'none'}, dedicated pixel)`)
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,7 @@ export const viewport: Viewport = {
 }
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://www.soumissionconfort.com'),
   title: "Soumission Confort - Estimation Gratuite d'Isolation d'Entretoit au Québec",
   description: "Obtenez votre estimation gratuite d'isolation d'entretoit en 60 secondes. Connectez-vous avec des entrepreneurs certifiés RBQ. Économisez jusqu'à 30% sur vos factures de chauffage. Subventions disponibles avec Hydro-Québec et RénoClimat.",
   generator: 'v0.dev',
@@ -36,7 +37,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Soumission Confort - Estimation Gratuite d'Isolation d'Entretoit au Québec",
     description: "Obtenez votre estimation gratuite d'isolation d'entretoit en 60 secondes. Connectez-vous avec des entrepreneurs certifiés RBQ. Économisez jusqu'à 30% sur vos factures de chauffage. Subventions disponibles avec Hydro-Québec et RénoClimat.",
-    url: 'https://soumissionconfort.com',
+    url: 'https://www.soumissionconfort.com',
     siteName: 'Soumission Confort',
     locale: 'fr_CA',
     type: 'website',
@@ -61,7 +62,7 @@ export default function RootLayout({
     "@type": "LocalBusiness",
     "name": "Soumission Confort",
     "description": "Estimation gratuite d'isolation d'entretoit au Québec. Entrepreneurs certifiés RBQ, subventions disponibles avec Hydro-Québec, LogisVert et RénoClimat.",
-    "url": "https://soumissionconfort.com",
+    "url": "https://www.soumissionconfort.com",
     "telephone": "+1-800-CONFORT",
     "priceRange": "$$",
     "areaServed": [


### PR DESCRIPTION
## Summary
- Apex `soumissionconfort.com` serves a GoDaddy **parking page**; the real app is on `www`. Hardcoded apex URLs in the home metadata broke social-share previews (`og:url` resolved to parking) and sent a contradictory canonical signal to Google.
- `app/layout.tsx`: add `metadataBase = https://www.soumissionconfort.com` (single source of truth + silences Next build warning), switch `openGraph.url` and the LocalBusiness JSON-LD `url` to `www`.
- `app/api/leads/route.ts`: align the Meta Conversion API `event_source_url` fallback to `www` so it matches the browser pixel (this fallback only fires when the `origin` header is absent — rare).

## Context
The apex→www **308 redirect is already configured Vercel-side** (project `soumission-confort-ai`). The remaining manual step is the GoDaddy DNS A-record swap (`@` → `76.76.21.21`, removing the parking A records). `www` + the funnel + the Meta pixel are untouched.

## Out of scope (intentional)
- `api/test-thermopompe` — thermopompe vertical is paused (RÈGLE #2).
- `/soumission-rapide*` pages — dead/orphan, 0 traffic, flagged for deletion.
- `lib/allowed-origins.ts` — apex kept in the allowlist on purpose (code already maps the `www.` variant; needed so apex-origin requests stay valid during the transition).

## Test plan
- [x] `npm run build` compiles clean; `/` prerenders static (metadataBase resolves at build, no warning).
- [ ] After GoDaddy DNS swap + cert: `curl -sI https://soumissionconfort.com/` → `308` + `location: https://www.soumissionconfort.com/`.
- [ ] `curl -s https://www.soumissionconfort.com/ | grep og:url` → shows `www`.
- [ ] `curl -sI https://www.soumissionconfort.com/` and `/pricing` → `200` (funnel + pixel intact).