### PR TITLE
fix(meta): trim pixel id/token env values (kills tracking on stray \n)

### DIFF
--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -299,9 +299,12 @@ export async function POST(request: NextRequest) {
           if (vertical !== 'isolation') {
             console.log(`[leads] skip Meta CAPI Lead — vertical='${vertical}' (shared channel disabled)`)
           } else {
-            const metaPixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT
-            const metaAccessToken = process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT
-            const metaTestEventCode = process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT
+            // .trim(): a trailing \n in the Vercel env value makes the CAPI POST
+            // hit graph.facebook.com/<id>%0A/events → Lead silently lost (incident
+            // 2026-06-03). Ids/tokens never carry meaningful edge whitespace.
+            const metaPixelId = (process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT || '').trim()
+            const metaAccessToken = (process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT || '').trim()
+            const metaTestEventCode = (process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT || '').trim() || undefined
 
             const isPlaceholder = (v?: string) => !!v && /^X+$/i.test(v)
             // Isolation Lead stays intent-gated (Zack v2 décision : qualified only).
@@ -788,9 +791,12 @@ export async function POST(request: NextRequest) {
           if (leadType !== 'isolation') {
             console.log(`[leads] skip Meta CAPI Lead — leadType='${leadType}', shared channel disabled (legacy path)`)
           } else {
-            const metaPixelId = process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT
-            const metaAccessToken = process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT
-            const metaTestEventCode = process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT
+            // .trim(): a trailing \n in the Vercel env value makes the CAPI POST
+            // hit graph.facebook.com/<id>%0A/events → Lead silently lost (incident
+            // 2026-06-03). Ids/tokens never carry meaningful edge whitespace.
+            const metaPixelId = (process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT || '').trim()
+            const metaAccessToken = (process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT || '').trim()
+            const metaTestEventCode = (process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT || '').trim() || undefined
 
             const isPlaceholder = (v?: string) => !!v && /^X+$/i.test(v)
             const intentGateOk = leadData.userAnswers?.intent === 'qualified'

--- a/components/meta-pixel-router.tsx
+++ b/components/meta-pixel-router.tsx
@@ -72,7 +72,10 @@ export const META_PIXEL_PARTAGE = ''
 const PIXEL_PARTAGE = META_PIXEL_PARTAGE
 // Exported so the wizard ViewContent + post-OTP Lead can target the dedicated
 // pixel with trackSingle (browser dedup vs CAPI).
-export const META_PIXEL_DEDIE = process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT || ''
+// .trim() guards a trailing newline/space in the Vercel env value: a stray \n
+// makes fbq init/trackSingle target "<id>\n" → "Pixel <id> not found" and zero
+// PageView/Lead fire (incident 2026-06-03). Pixel ids never have edge whitespace.
+export const META_PIXEL_DEDIE = (process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT || '').trim()
 
 function isPlaceholder(v: string): boolean {
   return !v || /^X+$/i.test(v)

--- a/lib/meta-config.ts
+++ b/lib/meta-config.ts
@@ -1,10 +1,18 @@
 import { initializeMetaConversionAPI } from './meta-conversion-api';
 
+// Trailing whitespace/newline in a Vercel env value silently kills Meta tracking:
+// a pixel id "<id>\n" makes browser fbq init/trackSingle target "<id>\n" ("Pixel
+// not found") AND the CAPI POST hit graph.facebook.com/<id>%0A/events → both
+// channels fail with nothing surfaced (incident 2026-06-03, dedicated pixel).
+// Ids/tokens/test-codes never carry meaningful edge whitespace, so always trim.
+const env = (v: string | undefined): string => (v ?? '').trim();
+const envOpt = (v: string | undefined): string | undefined => (v ?? '').trim() || undefined;
+
 // Meta Conversion API configuration
 export const META_CONFIG = {
-  PIXEL_ID: process.env.NEXT_PUBLIC_META_PIXEL_ID || '',
-  ACCESS_TOKEN: process.env.META_CONVERSION_ACCESS_TOKEN || '',
-  TEST_EVENT_CODE: process.env.META_TEST_EVENT_CODE || undefined,
+  PIXEL_ID: env(process.env.NEXT_PUBLIC_META_PIXEL_ID),
+  ACCESS_TOKEN: env(process.env.META_CONVERSION_ACCESS_TOKEN),
+  TEST_EVENT_CODE: envOpt(process.env.META_TEST_EVENT_CODE),
 };
 
 // Initialize Meta Conversion API on app startup
@@ -35,9 +43,9 @@ export function isMetaConfigured(): boolean {
 // shared pixel that keeps serving homepage/thermopompes/subventions/rapide).
 // ───────────────────────────────────────────────────────────────────────────
 export const META_CONFIG_SOUMISSIONCONFORT = {
-  PIXEL_ID: process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT || '',
-  ACCESS_TOKEN: process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT || '',
-  TEST_EVENT_CODE: process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT || undefined,
+  PIXEL_ID: env(process.env.NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT),
+  ACCESS_TOKEN: env(process.env.META_CONVERSION_ACCESS_TOKEN_SOUMISSIONCONFORT),
+  TEST_EVENT_CODE: envOpt(process.env.META_TEST_EVENT_CODE_SOUMISSIONCONFORT),
 };
 
 // True only when both id + token are real (not empty, not the XXXXXX


### PR DESCRIPTION
## Problème (incident 2026-06-03)

Le dataset Meta `1508005413751111` (Soumission Confort) ne recevait **plus aucun Lead ni PageView depuis ~2 jours**.

**Cause prouvée** : la var d'env Vercel prod `NEXT_PUBLIC_META_PIXEL_ID_SOUMISSIONCONFORT` contenait un **retour de ligne final** → valeur buildée `"1508005413751111\n"`.

- **Navigateur** : `fbq('init'/'trackSingle', "<id>\n")` → console `[Meta Pixel] Pixel 1508005413751111\n not found` → 0 PageView/Lead.
- **CAPI serveur** : POST vers `graph.facebook.com/<id>%0A/events` → Lead silencieusement perdu.

Les deux canaux lisent la même var → Lead mort à 100%.

## Fix

`.trim()` sur chaque lecture de pixel id / access token / test-event-code :
- `META_PIXEL_DEDIE` (navigateur — couvre router PageView + wizard ViewContent + lead-capture Lead + verifier-telephone Lead)
- `META_CONFIG` + `META_CONFIG_SOUMISSIONCONFORT` (helper `env()/envOpt()`)
- Les 2 blocs CAPI Lead dans `/api/leads`

`NEXT_PUBLIC` est inliné au **build** → le `.trim()` strip le `\n` au runtime. Immunité permanente au whitespace de bord (un pixel id/token n'en a jamais).

## Vérif
- ✅ tsc : aucune nouvelle erreur sur les fichiers touchés
- ✅ Codex adversarial-review : approve, no material findings
- ✅ Var prod Vercel re-set propre (16 chiffres, sans \n)
- ⏳ Vérif live post-deploy : `tr?id=1508005413751111&ev=PageView` + Lead qualified en Test Events

🤖 Generated with [Claude Code](https://claude.com/claude-code)