### PR TITLE
feat: copy iso « estimation » + EMQ Meta (advanced matching, fbp/fbc)

### DIFF
--- a/app/analysis/page.tsx
+++ b/app/analysis/page.tsx
@@ -152,7 +152,7 @@ export default function AnalysisPage() {
       case "questionnaire":
         return { title: "Détails du Projet", subtitle: "Parlez-nous de vos besoins", icon: Clock }
       case "lead-capture":
-        return { title: "Connexion aux Entrepreneurs", subtitle: "Nous vous mettons en contact avec des professionnels", icon: CheckCircle }
+        return { title: "Préparation de votre estimation", subtitle: "Nous préparons votre estimé personnalisé", icon: CheckCircle }
       case "pricing":
         return { title: "Résultats de Prix", subtitle: "Votre estimation personnalisée", icon: CheckCircle }
       default:

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -101,16 +101,18 @@ export async function POST(request: NextRequest) {
     // Meta CAPI advanced-matching extras (EMQ). fbp/fbc are the browser cookies
     // (_fbp/_fbc) forwarded in the payload so the CAPI Lead matches/dedups against
     // the browser Lead (the server can't read those cookies itself). If _fbc is
-    // absent but we captured an fbclid, rebuild it as fb.1.<seconds>.<fbclid>
-    // (timestamp is approximate but still improves matching). The email is reused
-    // as external_id (hashed inside trackLead).
+    // absent but we captured an fbclid, rebuild it as fb.1.<ms>.<fbclid>. Meta's
+    // fbc format uses the creation time in MILLISECONDS (13 digits, e.g.
+    // fb.1.1554763741205.<fbclid>) — a seconds value is treated as malformed and
+    // dropped. The timestamp is approximate (POST time, not the real click) but
+    // still improves matching. The email is reused as external_id (hashed in trackLead).
     const metaFbp: string | undefined =
       typeof leadData.fbp === 'string' && leadData.fbp ? leadData.fbp : undefined
     const metaFbc: string | undefined =
       typeof leadData.fbc === 'string' && leadData.fbc
         ? leadData.fbc
         : utmParams.fbclid
-          ? `fb.1.${Math.floor(Date.now() / 1000)}.${utmParams.fbclid}`
+          ? `fb.1.${Date.now()}.${utmParams.fbclid}`
           : undefined
 
     // Lead ID: honor a client-supplied value when it matches our format

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -98,6 +98,21 @@ export async function POST(request: NextRequest) {
     const utmParams = leadData.utmParams || {}
     console.log('🏷️ LEADS API: UTM Parameters received:', utmParams)
 
+    // Meta CAPI advanced-matching extras (EMQ). fbp/fbc are the browser cookies
+    // (_fbp/_fbc) forwarded in the payload so the CAPI Lead matches/dedups against
+    // the browser Lead (the server can't read those cookies itself). If _fbc is
+    // absent but we captured an fbclid, rebuild it as fb.1.<seconds>.<fbclid>
+    // (timestamp is approximate but still improves matching). The email is reused
+    // as external_id (hashed inside trackLead).
+    const metaFbp: string | undefined =
+      typeof leadData.fbp === 'string' && leadData.fbp ? leadData.fbp : undefined
+    const metaFbc: string | undefined =
+      typeof leadData.fbc === 'string' && leadData.fbc
+        ? leadData.fbc
+        : utmParams.fbclid
+          ? `fb.1.${Math.floor(Date.now() / 1000)}.${utmParams.fbclid}`
+          : undefined
+
     // Lead ID: honor a client-supplied value when it matches our format
     // (the funnel needs the ID in the URL before /api/leads is called when
     // OTP_ENABLED=true). Otherwise generate one server-side.
@@ -336,6 +351,9 @@ export async function POST(request: NextRequest) {
                 userAgent,
                 sourceUrl: `${origin}/analysis`,
                 eventId: leadData.eventId || undefined,
+                fbp: metaFbp,
+                fbc: metaFbc,
+                externalId: leadData.email,
                 customData: { service_type: 'isolation' },
               })
               console.log('✅ LEADS API: Meta CAPI Lead sent (GHL branch, isolation, dedicated pixel)')
@@ -833,6 +851,9 @@ export async function POST(request: NextRequest) {
                 userAgent,
                 sourceUrl: `${origin}/analysis`,
                 eventId: leadData.eventId || undefined,
+                fbp: metaFbp,
+                fbc: metaFbc,
+                externalId: leadData.email,
                 customData: {
                   service_type: 'isolation'
                 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   metadataBase: new URL('https://www.soumissionconfort.com'),
   title: "Soumission Confort - Estimation Gratuite d'Isolation d'Entretoit au Québec",
-  description: "Obtenez votre estimation gratuite d'isolation d'entretoit en 60 secondes. Connectez-vous avec des entrepreneurs certifiés RBQ. Économisez jusqu'à 30% sur vos factures de chauffage. Subventions disponibles avec Hydro-Québec et RénoClimat.",
+  description: "Obtenez votre estimation gratuite d'isolation d'entretoit en 60 secondes, basée sur les prix réels du marché québécois. Économisez jusqu'à 30% sur vos factures de chauffage. Subventions disponibles avec Hydro-Québec, LogisVert et RénoClimat.",
   generator: 'v0.dev',
   icons: {
     icon: [
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: "Soumission Confort - Estimation Gratuite d'Isolation d'Entretoit au Québec",
-    description: "Obtenez votre estimation gratuite d'isolation d'entretoit en 60 secondes. Connectez-vous avec des entrepreneurs certifiés RBQ. Économisez jusqu'à 30% sur vos factures de chauffage. Subventions disponibles avec Hydro-Québec et RénoClimat.",
+    description: "Obtenez votre estimation gratuite d'isolation d'entretoit en 60 secondes, basée sur les prix réels du marché québécois. Économisez jusqu'à 30% sur vos factures de chauffage. Subventions disponibles avec Hydro-Québec, LogisVert et RénoClimat.",
     url: 'https://www.soumissionconfort.com',
     siteName: 'Soumission Confort',
     locale: 'fr_CA',
@@ -61,7 +61,7 @@ export default function RootLayout({
     "@context": "https://schema.org",
     "@type": "LocalBusiness",
     "name": "Soumission Confort",
-    "description": "Estimation gratuite d'isolation d'entretoit au Québec. Entrepreneurs certifiés RBQ, subventions disponibles avec Hydro-Québec, LogisVert et RénoClimat.",
+    "description": "Estimation gratuite d'isolation d'entretoit au Québec, basée sur les prix réels du marché. Subventions disponibles avec Hydro-Québec, LogisVert et RénoClimat.",
     "url": "https://www.soumissionconfort.com",
     "telephone": "+1-800-CONFORT",
     "priceRange": "$$",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,15 +50,15 @@ const faqItems = [
   },
   {
     q: "Qui est Soumission Confort ?",
-    a: "Soumission Confort est une plateforme québécoise qui connecte les propriétaires avec des entrepreneurs certifiés RBQ pour leurs projets d'isolation. Nous avons aidé plus de 5 000 familles à réisoler leur grenier.",
+    a: "Soumission Confort est une plateforme québécoise qui aide les propriétaires à obtenir une estimation claire pour leurs projets d'isolation d'entretoit. Plus de 5 000 familles ont démarré leur réisolation avec nous.",
   },
   {
-    q: "Est-ce que je suis obligé de faire affaire avec un entrepreneur de votre réseau ?",
-    a: "Non. Après avoir reçu votre estimé, vous êtes entièrement libre de décider si vous souhaitez être mis en contact avec nos entrepreneurs. Il n'y a aucune pression et aucune obligation.",
+    q: "Est-ce que l'estimation m'engage à quelque chose ?",
+    a: "Non. L'estimation est gratuite et sans engagement. Vous êtes entièrement libre de décider de la suite. Aucune pression, aucune obligation.",
   },
   {
-    q: "Est-ce que les entrepreneurs sont tous vérifiés et certifiés par la RBQ ?",
-    a: "Oui. Tous nos entrepreneurs sont certifiés RBQ et vérifiés à 360° par notre équipe. En plus de valider leur licence RBQ, nous analysons leurs avis Google et les rencontrons personnellement avant de les intégrer à notre réseau.",
+    q: "Combien coûte l'isolation de mon entretoit ?",
+    a: "Ça dépend de la superficie et de l'état actuel de votre isolation. Notre outil vous donne un estimé réaliste en quelques minutes, basé sur les prix du marché québécois de l'isolation.",
   },
 ]
 
@@ -189,7 +189,7 @@ export default function HomePage() {
                   </button>
                 </div>
                 <div className="flex flex-wrap items-center justify-center gap-5">
-                  {["Gratuit et sans obligation", "150+ entrepreneurs certifiés", "Plateforme sécurisée"].map((text) => (
+                  {["Gratuit et sans obligation", "Estimation en quelques minutes", "Plateforme sécurisée"].map((text) => (
                     <div key={text} className="flex items-center gap-1.5">
                       <img src="/images/icon-check.svg" alt="" className="w-5 h-5" />
                       <span className="font-serif-body text-[#10002c] text-[15px] tracking-tight whitespace-nowrap">{text}</span>
@@ -210,7 +210,7 @@ export default function HomePage() {
               Comment ça fonctionne ?
             </h2>
             <p className="font-serif-body font-semibold text-[18px] text-[#375371] leading-[1.2] tracking-tight max-w-3xl">
-              Soumission Confort simplifie le démarrage des projets d'isolation des québecois grâce à un outil d'estimation basé sur l'intelligence artificielle et l'expérience d'un réseau de plus de 150 entrepreneurs certifiés par la RBQ.
+              Soumission Confort simplifie le démarrage des projets d'isolation des québecois grâce à un outil d'estimation basé sur l'intelligence artificielle et les prix réels du marché québécois de l'isolation.
             </p>
           </div>
 
@@ -228,13 +228,13 @@ export default function HomePage() {
               },
               {
                 img: "/images/card-documents.png",
-                title: "Vous choisissez si on vous accompagne dans votre recherche de soumission",
-                desc: "Aucune obligation. Vous décidez si vous souhaitez être mis en contact avec nos entrepreneurs certifiés.",
+                title: "Vous recevez votre estimation personnalisée",
+                desc: "Un estimé clair pour votre projet d'isolation, sans engagement.",
               },
               {
                 img: "/images/card-contractors.png",
-                title: "On trouve 3 soumissions d'entrepreneurs certifiés pour vous !",
-                desc: "Recevez jusqu'à 3 soumissions détaillées d'entrepreneurs RBQ vérifiés dans votre région.",
+                title: "On vous recontacte pour la suite",
+                desc: "Si vous le souhaitez, notre équipe vous accompagne pour passer de l'estimé au projet réalisé.",
               },
             ].map(({ img, title, desc }) => (
               <div key={title} className="bg-white border border-[#f2f2f7] rounded-[20px] p-8 shadow-md flex flex-col gap-6">
@@ -273,12 +273,12 @@ export default function HomePage() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
             {[
               {
-                title: "Les entrepreneurs nous paient pour les mettre en contact avec des propriétaires qui veulent faire leurs travaux.",
-                body: "Aucune pression. On mise sur la qualité de notre service avant tout.\n\nNotre meilleure façon de réussir, c'est de vous trouver l'entrepreneur idéal pour votre projet.",
+                title: "L'estimation est 100% gratuite et sans engagement.",
+                body: "Aucune pression. On mise sur la qualité de notre service avant tout.\n\nNotre but : vous donner l'heure juste sur votre projet d'isolation et vous accompagner seulement si vous le voulez.",
               },
               {
-                title: "Tous nos entrepreneurs sont certifiés RBQ et vérifiés à 360° par notre équipe.",
-                body: "Pour mériter la confiance de nos clients, nous sélectionnons nos entrepreneurs avec rigueur.\n\nEn plus de valider leur licence RBQ, nous analysons leurs avis Google et rencontrons personnellement chacun d'eux avant de les intégrer à notre réseau.",
+                title: "Une estimation fiable, basée sur les vrais prix du marché.",
+                body: "Pour mériter votre confiance, on s'appuie sur les prix réels du marché québécois et les caractéristiques de votre maison.\n\nVous obtenez un estimé clair pour démarrer votre projet d'isolation en toute transparence.",
               },
             ].map(({ title, body }) => (
               <div key={title} className="bg-white border border-[#f2f2f7] rounded-[20px] p-8 shadow-md flex flex-col gap-4">
@@ -293,7 +293,7 @@ export default function HomePage() {
           <div className="bg-[#aedee5] rounded-[20px] shadow-md px-8 py-12 w-full flex flex-wrap gap-12 items-center justify-center">
             {[
               { value: "5 000 +", label: "Projets d'isolation" },
-              { value: "150 +", label: "Entrepreneurs vérifiés" },
+              { value: "60 sec", label: "Pour votre estimé" },
               { value: "40%", label: "Économie moyenne" },
             ].map(({ value, label }) => (
               <div key={label} className="flex flex-col items-center gap-2 min-w-[140px]">

--- a/app/success/page.tsx
+++ b/app/success/page.tsx
@@ -20,19 +20,19 @@ function SuccessContent() {
       num: "1",
       icon: CheckCircle2,
       title: "Validation de votre projet",
-      desc: "Un membre de notre équipe valide rapidement les détails pour assurer un bon appariement avec les entrepreneurs.",
+      desc: "Un membre de notre équipe valide rapidement les détails de votre demande d'estimation.",
     },
     {
       num: "2",
       icon: Users,
-      title: "Appariement avec 3 entrepreneurs",
-      desc: "Nous sélectionnons des entrepreneurs certifiés et bien notés disponibles dans votre secteur pour votre type de projet.",
+      title: "On vous recontacte",
+      desc: "Notre équipe vous contacte pour discuter de votre estimé et des prochaines étapes de votre projet d'isolation.",
     },
     {
       num: "3",
       icon: Star,
-      title: "Réception de soumissions détaillées",
-      desc: "Comparez les prix, les matériaux et les délais. Notre objectif est de vous aider à économiser et choisir en confiance.",
+      title: "Vous décidez de la suite",
+      desc: "Sans engagement. Notre objectif est de vous aider à démarrer votre projet d'isolation en confiance.",
     },
   ]
 
@@ -86,12 +86,12 @@ function SuccessContent() {
           <p className="font-serif-body text-[#aedee5] text-lg max-w-xl mx-auto mb-8">
             {isContractor
               ? "Notre équipe examinera votre demande et vous contactera dans les prochaines 24-48 heures."
-              : <>Nous contactons les meilleurs entrepreneurs de votre région. Vous recevrez jusqu'à{" "}<strong className="text-white">3 soumissions détaillées</strong>{" "}dans les prochaines 24 heures.</>}
+              : <>Notre équipe vous recontacte dans les prochaines{" "}<strong className="text-white">24 heures</strong>{" "}au sujet de votre estimation d'isolation.</>}
           </p>
 
           {/* Trust badges */}
           <div className="flex flex-wrap justify-center gap-3 mb-10">
-            {["🔒 100% confidentiel", "⚡ Réponse sous 24h", "🤝 Sans engagement", "⭐ Entrepreneurs vérifiés"].map((b) => (
+            {["🔒 100% confidentiel", "⚡ Réponse sous 24h", "🤝 Sans engagement", "⭐ Service québécois"].map((b) => (
               <span
                 key={b}
                 className="flex items-center gap-1 bg-white/10 border border-white/20 rounded-full px-3 py-1.5 font-serif-body text-sm font-medium"
@@ -165,7 +165,7 @@ function SuccessContent() {
           <p className="font-serif-body text-[#375371] text-sm mb-6">
             {isContractor
               ? "Assurez-vous que votre profil est complet et que vous êtes prêt à répondre rapidement aux demandes."
-              : "Préparez quelques photos et précisez vos préférences de matériaux pour accélérer l'obtention de soumissions précises."}
+              : "Préparez quelques photos et notez vos préférences de matériaux pour accélérer le traitement de votre estimation."}
           </p>
           <Link href="/">
             <button className="flex items-center gap-2 mx-auto bg-[#b9e15c] border-2 border-[#002042] text-[#002042] font-heading font-bold py-3 px-8 rounded-full shadow-[-2px_4px_0_0_#002042] hover:shadow-[-1px_2px_0_0_#002042] hover:translate-y-0.5 transition-all">

--- a/app/verifier-telephone/page.tsx
+++ b/app/verifier-telephone/page.tsx
@@ -5,13 +5,7 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { CheckCircle, Loader2 } from "lucide-react"
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp"
-import { META_PIXEL_DEDIE } from "@/components/meta-pixel-router"
-
-declare global {
-  interface Window {
-    fbq: (...args: any[]) => void
-  }
-}
+import { fireBrowserLead } from "@/lib/meta-browser"
 
 type State = "sending" | "pending" | "confirming" | "submitting" | "verified" | "error"
 
@@ -201,22 +195,23 @@ export default function VerifierTelephonePage() {
           if (
             pending?.meta?.intent === "qualified" &&
             typeof pending.eventId === "string" &&
-            pending.eventId &&
-            typeof window !== "undefined" &&
-            typeof window.fbq === "function" &&
-            META_PIXEL_DEDIE &&
-            !/^X+$/i.test(META_PIXEL_DEDIE)
+            pending.eventId
           ) {
-            // Fire the browser Lead with the SAME eventId the CAPI Lead
-            // (/api/leads) uses → Meta dedups browser↔CAPI to ONE Lead. A fresh
-            // random id would NOT match the CAPI id and double-count. If eventId
-            // is missing (corrupt/stale sessionStorage), skip the browser pixel:
-            // the CAPI Lead still fires → counted once, never dropped.
-            window.fbq("trackSingle", META_PIXEL_DEDIE, "Lead", {
-              value: Number(pending.meta.estimatedValue || 0).toFixed(2),
-              currency: "CAD",
-              service_type: "isolation",
-            }, { eventID: pending.eventId })
+            // Browser Lead + advanced matching (em/ph/fn/ln from the stashed
+            // payload), fired with the SAME eventId the CAPI Lead (/api/leads)
+            // uses → Meta dedups browser↔CAPI to ONE Lead. A fresh random id
+            // would NOT match the CAPI id and double-count. If eventId is missing
+            // (corrupt/stale sessionStorage), skip: the CAPI Lead still fires →
+            // counted once, never dropped. The pixel-id/placeholder guard lives
+            // in fireBrowserLead.
+            fireBrowserLead({
+              email: pending.email,
+              phone: pending.phone,
+              firstName: pending.firstName,
+              lastName: pending.lastName,
+              value: Number(pending.meta.estimatedValue || 0),
+              eventId: pending.eventId,
+            })
           }
         }
       } catch (err) {

--- a/app/verifier-telephone/page.tsx
+++ b/app/verifier-telephone/page.tsx
@@ -268,7 +268,7 @@ export default function VerifierTelephonePage() {
                   {state === "sending"
                     ? "Envoi du code en cours..."
                     : state === "submitting"
-                    ? "Confirmation et envoi à nos entrepreneurs..."
+                    ? "Confirmation et envoi de votre demande..."
                     : (
                       <>
                         Un code de vérification a été envoyé par SMS au{" "}

--- a/components/insulation-results.tsx
+++ b/components/insulation-results.tsx
@@ -46,7 +46,7 @@ export function InsulationResults({ roofData, userAnswers, leadData, onComplete 
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">
           <div className="w-16 h-16 border-4 border-[#aedee5] border-t-[#002042] rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="font-serif-body text-[#375371]">Calcul de votre soumission personnalisée...</p>
+          <p className="font-serif-body text-[#375371]">Calcul de votre estimation personnalisée...</p>
         </div>
       </div>
     )
@@ -63,7 +63,7 @@ export function InsulationResults({ roofData, userAnswers, leadData, onComplete 
           <span className="font-serif-body font-semibold text-[#002042] text-sm">Analyse complétée</span>
         </div>
         <h1 className="font-heading text-3xl md:text-5xl font-bold text-[#10002c] mb-4">
-          Votre soumission d'isolation personnalisée
+          Votre estimation d'isolation personnalisée
         </h1>
         <p className="font-serif-body text-lg text-[#375371] max-w-2xl mx-auto">
           Basée sur {results.adjustedArea} pi² et vos besoins spécifiques
@@ -110,12 +110,12 @@ export function InsulationResults({ roofData, userAnswers, leadData, onComplete 
             }}
             className="w-full bg-[#b9e15c] border-2 border-white text-[#002042] font-heading font-bold py-5 px-8 rounded-full transition-all duration-300 shadow-[-2px_4px_0_0_rgba(255,255,255,0.4)] hover:shadow-[-1px_2px_0_0_rgba(255,255,255,0.4)] hover:translate-y-0.5 text-lg mb-4"
           >
-            <span className="hidden md:inline">Obtenir une soumission plus précise par des entrepreneurs</span>
-            <span className="md:hidden">Obtenir mes 3 soumissions gratuites</span>
+            <span className="hidden md:inline">Être recontacté pour mon projet</span>
+            <span className="md:hidden">Être recontacté pour mon projet</span>
           </button>
 
           <p className="font-serif-body text-center text-sm text-[#aedee5]">
-            ⚡ Obtenez des prix exacts en 24h • 100% gratuit
+            ⚡ Réponse sous 24h • 100% gratuit
           </p>
 
           <div className="mt-6 p-4 bg-white/10 rounded-xl border border-white/20">

--- a/components/lead-capture-form.tsx
+++ b/components/lead-capture-form.tsx
@@ -11,13 +11,7 @@ import { isValidQuebecPhone } from "@/lib/phone"
 import { getCurrentUTMParameters, type UTMParameters } from "@/lib/utm-utils"
 import { buildV1AnswersFromV2, type V2Answers } from "@/lib/funnel-config"
 import { calculateInsulationPricing } from "@/lib/insulation-calculator"
-import { META_PIXEL_DEDIE } from "@/components/meta-pixel-router"
-
-declare global {
-  interface Window {
-    fbq: (...args: any[]) => void
-  }
-}
+import { fireBrowserLead, getMetaBrowserCookies } from "@/lib/meta-browser"
 
 export interface LeadData {
   firstName: string
@@ -123,6 +117,11 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
       userAnswers: userAnswersPayload,
       pricingData,
       utmParams,
+      // Meta _fbp/_fbc cookies (set by fbevents, non-httpOnly) forwarded so the
+      // server CAPI Lead matches/dedups against the browser Lead (server can't
+      // read them). OTP path carries them too: this payload is stashed in
+      // sessionStorage and reposted by /verifier-telephone.
+      ...getMetaBrowserCookies(),
       // eventId stays top-level: /api/leads reads leadData.eventId for the CAPI
       // Lead, and /verifier-telephone reads pending.eventId for the browser
       // Lead → same id → Meta dedups browser↔CAPI (P0-3).
@@ -186,18 +185,15 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
       // succeeds — qualified intent only, same eventId as the CAPI Lead, targeted
       // at the dedicated pixel (trackSingle). When OTP is on, this fires from
       // /verifier-telephone instead (we return before reaching here).
-      if (
-        v2Answers.intent === 'qualified' &&
-        typeof window !== 'undefined' &&
-        typeof window.fbq === 'function' &&
-        META_PIXEL_DEDIE &&
-        !/^X+$/i.test(META_PIXEL_DEDIE)
-      ) {
-        window.fbq('trackSingle', META_PIXEL_DEDIE, 'Lead', {
-          value: estimatedValue.toFixed(2),
-          currency: 'CAD',
-          service_type: 'isolation',
-        }, { eventID: eventId })
+      if (v2Answers.intent === 'qualified') {
+        fireBrowserLead({
+          email: formData.email,
+          phone: formData.phone,
+          firstName: formData.firstName,
+          lastName: formData.lastName,
+          value: estimatedValue,
+          eventId,
+        })
       }
 
       onComplete(pricingData, leadDataForReturn, clientLeadId)

--- a/components/lead-capture-form.tsx
+++ b/components/lead-capture-form.tsx
@@ -327,7 +327,7 @@ export function LeadCaptureForm({ roofData, v2Answers, onComplete }: LeadCapture
           </div>
           <div className="flex items-center gap-1.5 font-serif-body text-sm text-[#375371]">
             <CheckCircle className="w-4 h-4 text-[#002042]" />
-            <span>Entrepreneurs certifiés RBQ</span>
+            <span>Sans engagement</span>
           </div>
         </div>
       </div>

--- a/lib/meta-browser.ts
+++ b/lib/meta-browser.ts
@@ -1,0 +1,79 @@
+import { META_PIXEL_DEDIE } from '@/components/meta-pixel-router'
+import { toMetaPhone } from '@/lib/phone'
+
+declare global {
+  interface Window {
+    fbq: (...args: any[]) => void
+  }
+}
+
+// Browser-side Lead with manual Advanced Matching (EMQ uplift, 2026-06).
+//
+// The browser Lead used to send NO user_data (only value/currency/service_type),
+// so Meta could only match on cookies → low Event Match Quality. Meta's manual
+// advanced matching is set PER PIXEL via `fbq('init', pixelId, userData)` (stored
+// in pixelsByID[pixelId].userData) and read by the NEXT trackSingle — it is NOT
+// passed inside the event's custom_data. So we re-init the dedicated pixel with
+// {em, ph, fn, ln} right before firing, then trackSingle the Lead. fbevents hashes
+// em/ph/fn/ln client-side itself, so we pass them in clear (lowercased/E.164) — no
+// manual SHA-256 here. Re-init only updates the matching data; it fires no PageView
+// (disablePushState is already set, autoConfig already false) so it's side-effect free.
+//
+// The SAME eventId must be passed here and to the CAPI Lead (/api/leads) so Meta
+// dedups browser↔CAPI to one Lead — callers own that id; we just forward it.
+export function fireBrowserLead(params: {
+  email?: string
+  phone?: string
+  firstName?: string
+  lastName?: string
+  value?: number
+  eventId?: string
+}): void {
+  if (typeof window === 'undefined' || typeof window.fbq !== 'function') return
+  // Mirror the dedicated-pixel guard used at every fbq call-site: never fire when
+  // the pixel id is missing or the XXXXXX placeholder.
+  if (!META_PIXEL_DEDIE || /^X+$/i.test(META_PIXEL_DEDIE)) return
+
+  // Build advanced matching with only the fields we actually have. Phone in Meta's
+  // canonical digits-only form (toMetaPhone) — the exact string fbevents hashes —
+  // so the browser hash and the CAPI hash match for the same lead.
+  const am: Record<string, string> = {}
+  const em = params.email?.trim().toLowerCase()
+  if (em) am.em = em
+  const ph = toMetaPhone(params.phone)
+  if (ph) am.ph = ph
+  const fn = params.firstName?.trim().toLowerCase()
+  if (fn) am.fn = fn
+  const ln = params.lastName?.trim().toLowerCase()
+  if (ln) am.ln = ln
+
+  if (Object.keys(am).length > 0) {
+    window.fbq('init', META_PIXEL_DEDIE, am)
+  }
+
+  window.fbq(
+    'trackSingle',
+    META_PIXEL_DEDIE,
+    'Lead',
+    { value: (params.value ?? 0).toFixed(2), currency: 'CAD', service_type: 'isolation' },
+    params.eventId ? { eventID: params.eventId } : undefined,
+  )
+}
+
+// Reads the _fbp / _fbc cookies fbevents.js sets (non-httpOnly) so they can be
+// forwarded to the server CAPI Lead. The browser already sends fbp/fbc with its
+// own events, so the CAPI Lead must send the SAME values to match/dedup against
+// it — server-side getClientInfo() can't read them. Returns only present keys.
+export function getMetaBrowserCookies(): { fbp?: string; fbc?: string } {
+  if (typeof document === 'undefined') return {}
+  const read = (name: string): string | undefined => {
+    const m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'))
+    return m ? decodeURIComponent(m[1]) : undefined
+  }
+  const out: { fbp?: string; fbc?: string } = {}
+  const fbp = read('_fbp')
+  if (fbp) out.fbp = fbp
+  const fbc = read('_fbc')
+  if (fbc) out.fbc = fbc
+  return out
+}

--- a/lib/meta-conversion-api.ts
+++ b/lib/meta-conversion-api.ts
@@ -1,3 +1,5 @@
+import { toMetaPhone } from './phone';
+
 interface MetaConversionEvent {
   event_name: string;
   event_id?: string;
@@ -12,6 +14,7 @@ interface MetaConversionEvent {
     client_user_agent?: string;
     fbc?: string; // Facebook click ID
     fbp?: string; // Facebook browser ID
+    external_id?: string; // stable id (hashed) — improves match quality
   };
   custom_data?: {
     content_type?: string;
@@ -172,6 +175,9 @@ export class MetaConversionAPI {
     userAgent?: string;
     sourceUrl?: string;
     eventId?: string;
+    fbp?: string;
+    fbc?: string;
+    externalId?: string;
     customData?: Record<string, any>;
   }) {
     try {
@@ -180,7 +186,13 @@ export class MetaConversionAPI {
       };
 
       if (leadData.phone) {
-        userData.ph = await hashData(leadData.phone);
+        // Hash the Meta-canonical phone (digits only, country code, no '+') — the
+        // EXACT string fbevents hashes client-side, so the browser AM hash and the
+        // CAPI hash match AND the value is in Meta's expected format. The E.164
+        // "+1..." would hash differently (the '+' survives hashData) and waste the
+        // phone signal. Skip ph entirely if no digits can be derived.
+        const ph = toMetaPhone(leadData.phone);
+        if (ph) userData.ph = await hashData(ph);
       }
       if (leadData.firstName) {
         userData.fn = await hashData(leadData.firstName);
@@ -188,7 +200,20 @@ export class MetaConversionAPI {
       if (leadData.lastName) {
         userData.ln = await hashData(leadData.lastName);
       }
-      
+
+      // fbp/fbc are sent RAW (never hashed) — they're the same cookie values the
+      // browser Lead already sends, so the two channels match/dedup. external_id
+      // is hashed (Meta convention); we use the email as the stable id.
+      if (leadData.fbp) {
+        userData.fbp = leadData.fbp;
+      }
+      if (leadData.fbc) {
+        userData.fbc = leadData.fbc;
+      }
+      if (leadData.externalId) {
+        userData.external_id = await hashData(leadData.externalId);
+      }
+
       // Add server-side client information
       if (leadData.clientIp) {
         userData.client_ip_address = leadData.clientIp;
@@ -205,7 +230,7 @@ export class MetaConversionAPI {
         user_data: userData,
         custom_data: {
           content_type: 'lead_form',
-          content_name: 'Roof Quote Request',
+          content_name: 'Estimation isolation',
           value: leadData.value || 0,
           currency: 'CAD',
           ...(leadData.customData || {})

--- a/lib/phone.ts
+++ b/lib/phone.ts
@@ -52,6 +52,20 @@ export function normalizePhone(input: string | null | undefined): string | null 
 }
 
 /**
+ * Meta advanced-matching / Conversions API phone format: digits only, with the
+ * country code, NO '+' or symbols (e.g. "15145551234"). fbevents.js normalizes
+ * the in-clear phone the SAME way before hashing client-side, so feeding this
+ * exact string to BOTH the browser pixel and the CAPI yields identical hashes —
+ * the E.164 "+15145551234" would hash differently (the '+' survives) and the
+ * phone match signal is silently lost. Returns null when no digits can be derived.
+ */
+export function toMetaPhone(input: string | null | undefined): string | null {
+  const e164 = normalizePhone(input)
+  const digits = (e164 ?? (typeof input === 'string' ? input : '')).replace(/\D/g, '')
+  return digits || null
+}
+
+/**
  * Format for display: `(514) 555-1234`. Returns the input untouched if invalid.
  */
 export function formatPhoneForDisplay(input: string): string {


### PR DESCRIPTION
## Summary
- **Copy** : retire l'ancien modèle « 3 soumissions d'entrepreneurs / les entrepreneurs nous paient » de TOUTES les surfaces iso à trafic (`/`, `/analysis`, `/pricing`, `/verifier-telephone`, chemin client `/success`, meta SEO `layout.tsx`) → recentre sur « estimation gratuite + recontact, sans engagement ». Pages mortes/`isContractor` non touchées.
- **EMQ Meta** : advanced matching navigateur (`em/ph/fn/ln` via `fbq('init', pixel, ...)` avant `trackSingle`, helper `lib/meta-browser.ts`) ; CAPI Lead reçoit `fbp`/`fbc` (forwardés depuis les cookies `_fbp`/`_fbc`, fbc reconstruit depuis `fbclid` en fallback) + `external_id`=sha256(email) ; `content_name` corrigé.
- **Fix hash téléphone** (trouvé en review adversariale) : `toMetaPhone()` canonique (digits-only + country code, sans `+`) partagé navigateur↔CAPI → les 2 hashent la même chaîne, le signal `ph` matche. Dédup browser↔CAPI préservée (même `eventId`), gates `qualified`-only + `!isTest` intacts.

## Test plan
- `next build` ✓ « Compiled successfully », 87/87 pages ; `tsc` 0 erreur sur les fichiers modifiés.
- Review adversariale multi-agents (copy completeness = clean, EMQ correctness, régression imports/flow, hygiène) → 1 bug HIGH (hash tel) trouvé + corrigé.
- **Post-merge (live)** : drive le funnel réel → capter `facebook.com/tr` du Lead (`ev=Lead`, `id=<pixel>`, params advanced matching `ud[em]`/`ud[ph]` présents) + cookies `_fbp`/`_fbc` ; POST CAPI synthétique (test_event_code, non-prod) → `events_received:1` avec `fbp`/`fbc`/`external_id` ; Events Manager → score EMQ du Prospect remonte (48-72h) ; vérif visuelle copy sur les 5 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)